### PR TITLE
Feat/backend user compliance

### DIFF
--- a/docs/swagger-1.8.json
+++ b/docs/swagger-1.8.json
@@ -393,6 +393,49 @@
         }
       }
     },
+    "/user/report": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "report a user with reason",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json:": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportUserRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "report user success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "Message"
+                  ],
+                  "properties": {
+                    "Message": {
+                      "type": "string",
+                      "example": "Report user success"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/user/delete": {
       "delete": {
         "tags": [
@@ -1111,6 +1154,23 @@
           }
         }
       },
+      "ReportUserRequest": {
+        "type": "object",
+        "required": [
+          "name",
+          "reason"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9 ]*$",
+            "maxLength": 20
+          }
+        }
+      },
       "AccessToken": {
         "type": "object",
         "required": [
@@ -1245,7 +1305,7 @@
           "comment": {
             "type": "string",
             "maxLength": 150,
-            "pattern": "^[\\x00-\\x7F]+$"
+            "pattern": "^[ -~]+$"
           },
           "timestamp": {
             "type": "integer",
@@ -1535,7 +1595,7 @@
           "comment": {
             "type": "string",
             "maxLength": 150,
-            "pattern": "^[\\x00-\\x7F]+$"
+            "pattern": "^[ -~]+$"
           }
         }
       },

--- a/docs/swagger-1.8.json
+++ b/docs/swagger-1.8.json
@@ -8,7 +8,7 @@
   ],
   "info": {
     "description": "This is the RouteMaker API",
-    "version": "1.7",
+    "version": "1.8",
     "title": "RouteMaker API",
     "contact": {
       "email": "yarkhinephyo@gmail.com"
@@ -341,6 +341,54 @@
           },
           "401": {
             "$ref": "#/components/responses/UnauthorizedError"
+          }
+        }
+      }
+    },
+    "/user/disable": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "disables a user as admin",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json:": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "format": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "disable user success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "Message"
+                  ],
+                  "properties": {
+                    "Message": {
+                      "type": "string",
+                      "example": "Disable user success"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/docs/swagger-1.8.json
+++ b/docs/swagger-1.8.json
@@ -1197,8 +1197,8 @@
           },
           "routeName": {
             "type": "string",
-            "maxLength": 50,
-            "pattern": "^[a-zA-Z0-9 \\-]*$"
+            "maxLength": 30,
+            "pattern": "^[ -~]+$"
           },
           "gymLocation": {
             "type": "string",

--- a/docs/swagger-1.8.json
+++ b/docs/swagger-1.8.json
@@ -530,7 +530,7 @@
         }
       }
     },
-    "/route/details/vote": {
+    "/route/details/upvote": {
       "post": {
         "tags": [
           "route"
@@ -1327,7 +1327,7 @@
           "publicGrade",
           "publicGradeSubmissions",
           "voteCount",
-          "upVotes",
+          "upvotes",
           "reports",
           "commentCount",
           "comments"
@@ -1370,7 +1370,7 @@
             "type": "integer",
             "format": "int32"
           },
-          "upVotes": {
+          "upvotes": {
             "type": "array",
             "items": {
               "type": "string"

--- a/lambda_backend/cognito_setup/serverless.yml
+++ b/lambda_backend/cognito_setup/serverless.yml
@@ -35,6 +35,10 @@ resources:
           # Ensure SES has AWS production access
           # EmailSendingAccount: DEVELOPER
           # SourceArn: <arn:email>
+        Schema:
+          - Name: role
+            Mutable: true
+            AttributeDataType: String
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
       Properties:

--- a/lambda_backend/database_setup/serverless.yml
+++ b/lambda_backend/database_setup/serverless.yml
@@ -116,21 +116,21 @@ custom:
   _routeDataTable:
     ReadCapacityUnits:
       dev: 2
-      prod: 6
+      prod: 4
     WriteCapacityUnits:
       dev: 2
-      prod: 6
+      prod: 4
   _routeDataTableGSI:
     ReadCapacityUnits:
       dev: 2
-      prod: 4
+      prod: 8
     WriteCapacityUnits:
       dev: 2
       prod: 4
   _gymDataTable:
     ReadCapacityUnits:
       dev: 1
-      prod: 2
+      prod: 3
     WriteCapacityUnits:
       dev: 1
-      prod: 2
+      prod: 1

--- a/lambda_backend/postman_collections/Bouldering - Route.postman_collection.json
+++ b/lambda_backend/postman_collections/Bouldering - Route.postman_collection.json
@@ -35,11 +35,6 @@
               "key": "token",
               "value": "{{AccessToken}}",
               "type": "string"
-            },
-            {
-              "key": "password",
-              "value": "{{{{AccessToken}}}}",
-              "type": "string"
             }
           ]
         },

--- a/lambda_backend/postman_collections/Bouldering - Route.postman_collection.json
+++ b/lambda_backend/postman_collections/Bouldering - Route.postman_collection.json
@@ -33,7 +33,12 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "value": "{{AccessToken}}",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{{{AccessToken}}}}",
               "type": "string"
             }
           ]
@@ -99,7 +104,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -114,14 +119,14 @@
           }
         ],
         "url": {
-          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route?createdAt=2021-06-16T15:11:18.602Z&username=yarkhinephyo",
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route?createdAt=2021-06-20T11:48:45.490Z&username=yarkhinephyo",
           "protocol": "https",
           "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
           "path": ["dev", "route"],
           "query": [
             {
               "key": "createdAt",
-              "value": "2021-06-16T15:11:18.602Z"
+              "value": "2021-06-20T11:48:45.490Z"
             },
             {
               "key": "username",
@@ -160,7 +165,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiZDMwMWE3ZjUtN2MyZi00YThmLWFmODItNmRmNWRkODZhNGJhIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiIxZTU0NGQ1ZS1mMDk4LTQ3ODQtOGQ4MC0xNzEyNjVhYzQxMDAiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU0NjY4LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQxMDY4LCJpYXQiOjE2MjM4NTQ2NjgsImp0aSI6IjY0ZDUwNGQ3LTU1MWUtNGE1Ny1iMDI5LTc5ZjU0YjQ5MzJjMyIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.hIyVrUvJMOnI_dnYJOuD-yiTFhCUnH9eWy0NoU1KmYTwSS58sETeG9ezy--0EjRHDgOLtP7f4HofeOiour9eUglUMB1AciXcA_X5f5Il9aaWxHeVhpG0WRygIFNACu_jEKJxm1nCVAi-6mGw0u8gsLOWSf_VWOtxuWihMjI5eZzLJqnYrA5AfSb5f9IuC6SnDZgtlS5Y6oBp4ZvCxrNedVJTFSxVv9_0BVDK160d9KCnocAuw856khEM6Gbg-LkVeWVPXyx006GszKgQI4bMMl3qk0PPuw4uYZ7YWJ1UlSA1vZ1SmGzQofVoPjHx3ENcFV64gXNI1-LrXfG9its9VA",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -169,7 +174,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-16T15:11:18.602Z\"\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-20T11:44:19.130Z\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -193,7 +198,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -226,7 +231,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -268,7 +273,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -301,7 +306,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -334,7 +339,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJYTmk5ZFwvY1JcL3haTXJ4dytOQVJPemNpSUNacUJzdU90WXc1ME9uSWNzc0k9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJiMGJjYTRkMy0xODYyLTQ4M2UtOTcyMi05MDQxOWYyMDdjMzkiLCJldmVudF9pZCI6ImVmODRkYWQwLTE4YTgtNGVmZi1hZTY3LWQxNzlkMGVhZTk0MCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MTk5MjQ5OTEsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV9JMFk5WEZpUTkiLCJleHAiOjE2MTk5NDY1OTEsImlhdCI6MTYxOTkyNDk5MSwianRpIjoiYTIwZjkwZTAtZmRiNC00OGM4LWFkZjktZTI4MWY5OTkxOWFjIiwiY2xpZW50X2lkIjoiNTJjZHI4MTJtczFldjdmcDZsdnZscHJzMWMiLCJ1c2VybmFtZSI6ImIwYmNhNGQzLTE4NjItNDgzZS05NzIyLTkwNDE5ZjIwN2MzOSJ9.TlhxAz_RTUA-kaMmIal7hr-xfpGhsmHi_X5qHJzze0jIoAfM_0K4LDZY80QarRDRAPBzUse9EjejwsU1wuPzeMVbv4b0-2IDAV5dh1BMyBaY0OoPRIexmF9cVpoxsbMEPVh-XNziYF9ILDOGCcJ33W-B2HeNX9AEmHTd1uqJinL70ocH5aHU6PkCLAW-40552NV7dNrd4U4v0ARqJg4hZyfkfu5Cf3YYAYwOY9aIZvWPn68PUO33iWx9J-F290s0hgU7-USEEYifgyah68FxXhUQp9E4hwp81CQgHu36HdZq-YZN0hBQene7GfaPNIQI0hk7LVlfj1CS8Xv2OHZpMQ",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -343,7 +348,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"b0bca4d3-1862-483e-9722-90419f207c39\",\r\n    \"createdAt\": \"2021-05-02T04:05:37.072Z\"\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-20T11:54:36.226Z\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -367,7 +372,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiZDMwMWE3ZjUtN2MyZi00YThmLWFmODItNmRmNWRkODZhNGJhIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiIxZTU0NGQ1ZS1mMDk4LTQ3ODQtOGQ4MC0xNzEyNjVhYzQxMDAiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU0NjY4LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQxMDY4LCJpYXQiOjE2MjM4NTQ2NjgsImp0aSI6IjY0ZDUwNGQ3LTU1MWUtNGE1Ny1iMDI5LTc5ZjU0YjQ5MzJjMyIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.hIyVrUvJMOnI_dnYJOuD-yiTFhCUnH9eWy0NoU1KmYTwSS58sETeG9ezy--0EjRHDgOLtP7f4HofeOiour9eUglUMB1AciXcA_X5f5Il9aaWxHeVhpG0WRygIFNACu_jEKJxm1nCVAi-6mGw0u8gsLOWSf_VWOtxuWihMjI5eZzLJqnYrA5AfSb5f9IuC6SnDZgtlS5Y6oBp4ZvCxrNedVJTFSxVv9_0BVDK160d9KCnocAuw856khEM6Gbg-LkVeWVPXyx006GszKgQI4bMMl3qk0PPuw4uYZ7YWJ1UlSA1vZ1SmGzQofVoPjHx3ENcFV64gXNI1-LrXfG9its9VA",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -391,6 +396,12 @@
         }
       },
       "response": []
+    }
+  ],
+  "variable": [
+    {
+      "key": "AccessToken",
+      "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNzJiNDNhNWMtODNlYi00MDhjLWI0ZDAtNWQ5Y2RjMzZkY2EzIiwic3ViIjoiMzM0OTMxYmYtNjJlZS00Mzg5LWJmMGEtMzk5ZTlkYTYyMWMzIiwiZXZlbnRfaWQiOiI0ODYxMTI2OC1hOGFmLTQ3ZGUtOTlkMi1jMTQ4ZGM1YzViZGEiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjI0MTg1MDI0LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjI0MjcxNDI0LCJpYXQiOjE2MjQxODUwMjQsImp0aSI6IjJjYmZjZmZmLTE4ZTMtNGEwZi1iZTQ5LTRjNjg0ZTEwZTBmZCIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.np3z_MtadpZeb2NK3-Hb9vSGl00Ee8XbTf4Dne84_JmCyqsi7z9IH_-xkeiTEkAWtsXuCwC2r_ZTxkJFzY2MM7TWxN74DbANFguoY0yYkVhs_aSej0MerjX4AkJLbUw_5utF0GixMv26Wl6m4lABVqpw0JigGRiGoxCXfdqWdlYQAfK4TuP2pa0ygBRze-gHp9UTFcfy2vx4_l9bYkCOvtrQPvaVq394CegacuOEZ5xsGZdGtYm7E0nqlUXmY0L0KLaceMfMmsruS9f20O9RhEbe3B4BhD7edNQyDpqbaFmXKU9dDM2yg3GyZ_hpcNHg3_LFfNeJi2GgU939ivnBxA\""
     }
   ]
 }

--- a/lambda_backend/postman_collections/Bouldering - Route.postman_collection.json
+++ b/lambda_backend/postman_collections/Bouldering - Route.postman_collection.json
@@ -35,6 +35,11 @@
               "key": "token",
               "value": "{{AccessToken}}",
               "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{{{AccessToken}}}}",
+              "type": "string"
             }
           ]
         },
@@ -114,14 +119,14 @@
           }
         ],
         "url": {
-          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route?createdAt=2021-06-20T11:48:45.490Z&username=yarkhinephyo",
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route?createdAt=2021-06-20T14:31:08.195Z&username=yarkhinephyo",
           "protocol": "https",
           "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
           "path": ["dev", "route"],
           "query": [
             {
               "key": "createdAt",
-              "value": "2021-06-20T11:48:45.490Z"
+              "value": "2021-06-20T14:31:08.195Z"
             },
             {
               "key": "username",
@@ -169,7 +174,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-20T11:44:19.130Z\"\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-22T03:21:14.754Z\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -202,7 +207,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-16T15:11:18.602Z\"\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-22T14:55:20.359Z\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -210,10 +215,10 @@
           }
         },
         "url": {
-          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/vote",
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/upvote",
           "protocol": "https",
           "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
-          "path": ["dev", "route", "details", "vote"]
+          "path": ["dev", "route", "details", "upvote"]
         }
       },
       "response": []
@@ -310,7 +315,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-16T15:11:18.602Z\",\r\n    \"comment\": \"This is a comment by me and this cannot be more than 150 chars\"\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-22T03:21:14.754Z\",\r\n    \"comment\": \"This is a comment by me and this cannot be more than 150 chars\"\r\n}",
           "options": {
             "raw": {
               "language": "json"

--- a/lambda_backend/postman_collections/Bouldering - User.postman_collection.json
+++ b/lambda_backend/postman_collections/Bouldering - User.postman_collection.json
@@ -35,7 +35,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"name\": \"yarkhinephyo\",\r\n    \"code\": \"754414\"\r\n}",
+          "raw": "{\r\n    \"name\": \"yarkhinephyo\",\r\n    \"code\": \"223017\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -233,6 +233,39 @@
           "protocol": "https",
           "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
           "path": ["dev", "user", "logout"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Report User",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{AccessToken}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"name\": \"testing\",\r\n    \"reason\": \"spammer\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/report",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "report"]
         }
       },
       "response": []

--- a/lambda_backend/postman_collections/Bouldering - User.postman_collection.json
+++ b/lambda_backend/postman_collections/Bouldering - User.postman_collection.json
@@ -35,7 +35,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"name\": \"yarkhinephyo\",\r\n    \"code\": \"536856\"\r\n}",
+          "raw": "{\r\n    \"name\": \"yarkhinephyo\",\r\n    \"code\": \"754414\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -123,6 +123,16 @@
     {
       "name": "Log In",
       "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{AccessToken}}",
+              "type": "string"
+            }
+          ]
+        },
         "method": "POST",
         "header": [],
         "body": {
@@ -144,13 +154,46 @@
       "response": []
     },
     {
+      "name": "Disable User",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{AccessToken}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"name\": \"testingboy\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/disable",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "disable"]
+        }
+      },
+      "response": []
+    },
+    {
       "name": "Refresh Token",
       "request": {
         "method": "POST",
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"refreshToken\": \"eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.rVTHcObKSTOOjW7pqtd_zmmjP1bjETsBIFurLcoFCVQGSg4Wga3hR3--lKTRa-oad8G4lkQNPT6QHx1297IniEyX_ufOceA8ViuyWIiknYOoOqoyqmpET6WajvGJVyiERZabfus6lGA5DJd8oGvHQjSGJHXlSsVpdS7M69ocxfh9fUZ6SY9adcfMn2HtzF08YPSGSWRifVA2qoq2vq3viprnywgxoP2DRUxTa9ibXZFR31teqzELTjhshmNiGWjJghT248QPcN2wvuO7ra5R4OFXmiw6ZTA43Bo0OSQvwPPyqwWkpk2LcdLmLitm4ejy5pgVEuKtLJ0qwlP-NEh1jw.W_OITFTRIkXKSPvc.2yXwW6xMf25yiLWiTGkfk747nYuZIZ7f_SKp48YAj1UpfTJ4uVBKDJONVvTb38ZEnIP9lBbrds5OS4dBCbfXsq1JSz_bKRLXClSOjwAGSQjXYHD9t7Wp78PflJBEHOFIC26FwTr-79pjLMXdA0X30DOsmdQyCrSzba8ukSC0u9bnSuXZu_Wk2uMzfwRP-aYaEQU3MVXD6LeqozTVs_Rj7W5dljVPUwT5VZCCLc_du-Xo1TAljPe_3-usCBko0shBe2-hI5pDGLFef4poC9-22pIT5iYdHqYAOa-_DoUaP-3Y4ukxD2rPFFs1zbtgkN84m4Ri-KU8I7eufzpc3qzrz9rSsnh2tpskrky6V1uzmdiAs6VKV5P9CuNl3MdWfoeNuEHhmQN-bQh35ErZ2lZbcI7e-ZAzI8nIw679jtcigG0PW4ns4cjpg2MK3poQ6H_SQK_us-F3PUktpi8apv9nmqN3kPpPOdOLIh_pLqHM3D2jJoFk75b0qZdiO2Iz46ZBjK5NCcRa8rbE7U48UjJ7O6ngzIqIBY8VkwpMLrhmnUNLv6tjgxtS1TSD6JzdOx6_Nc7nJaZZMFDxPk3oyNUl1EwcDFP8fGbgjHrIUVa65plE_WV_sfyD_z6DfkIbDGaWq6CG-fHPY-vqrysZKXWpshtM0Kia2UzoMr4S5svESEu-AoByURK240lhnIaahljwQigEzvgOmkPJARR9dyg_qE2DleVb7ar4-lgyNrghejnY-n-BRkyx_phh2YaQ7bkkPvU6vdc06_a49FWEapxqc7XRKjQTJUu0YON6hbpGjuXlpjaE35RTAA1DXWQ0SACqy9OsZiNdWT-mnxHVnCRtXpEvz_8xUBvnrFn91GstTZPQxkWwrBWIc3FM3cfy3EMhHUOrNbfKq5atHSqvo4JQ92yA4W5QMy5gLutY1VuM040bkj_lTu8l7Fwc3rOaAE1bxheg8j8Inw40WO23D_fl7_LTQMUQPQq5zNACvmFTxQIG2x-e5vI1X4ANB6zBfDI8ukeixwFCagr9fN0dZ0EiMpuBa0AGbvArNNFhpcU_Rne_qQhoZi0RirAd_iiCdrc4in-VkunmUvDUeilkG6nrC9sL76F6FfbexJcJhgkaXrPTAPXdBzmQ102iu2tbkmFYGbP3K7oOIgabr7ihQkBFpoZvHnKV663SPMHtjoghxBr3v-BG6TD2KY2rK_KT0dsnZTia_38QUXL8mvlYS9H5uzO0nLwvf78-5obYYZDbyONK5W9FEVgsNPHoF66t7B9vXbb8m1zXIVZ-1aMJVrrfZBYrRb_nvryYQY3478rKLA0zFmt7x04TeaDKwSCYAGESJ4V8ws7gsA.ojYJzYRUQjoN4RYMRp_RQg\"\r\n}",
+          "raw": "{\r\n    \"refreshToken\": \"eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.BriGs4y2sS9fGgs_si1JDbZsVVy1PnYMVXIvWidFWe0B2hSK9s6_L9BFo-SGrjAXzVer05iC9MqSBtyWeuVA0pfsFT4D11E-0FruOvmqk5pB_rB4476E650f8cB8Be0GZna5jD4t0Q0mSjwwGTL24VzqkY_r6ElzGxV-PROekQt4ztwH3APNyrnExXyhKmFVCq7-blJazHLVpIjhxbUNyYQ_tdASN_5ERNHph9j1E6AehZUDUtjm130YNjbx8hZ_1kSgyR4aEL8ibB1I4zQnh5xrw9PJcvParo7zhh6iwmecksoPTMfR4qScE-WkzWWV-wd-a-KMzhXj4IwWYJfzKg.Q8ogcFEEZ4VN8wll.gqqhJznMvIr7DxUE4G59aBS000P4ObOxOSaFghhgRt4p7DVwFc9cc2soP4CG9QLlofUZyTJYW2rhOrWurSrd6tT-niC_39Xr5eDJ5nxJjdRLDuUF23WmQD8BetSzPfz-MMZhhNxuvk-GCL3Tbe4s5baRDUPdtOsGypIkjcJr0rzyCwfymJrXkOAsN9-zITSEfL1ULseXE0xSVtW0mwL3s_5GV45oZUejlHhfvK89z-NFQsG-BWgUvT40JCTMm9RrAMGB_qcIJV2gTR7RBcCnqIzb-RvvTqnOHky-GjqEUT5si1UPSP60tp-PsBPvOGTzw61QLh2USZx04ylKmc_PCrfTxcTw0oU5pZ3_zYEG7Oc2Ad0nUISp48gtWNqhepWFSRFYLIUwNW2yeX6QciydEX9-fNz3DKSEOdYpFq80HKEsyvgpF9-SuLWDkfsuurXlA0B8IhiBdUZf4odx_vCqQVOhCN6NxLratq9xPSwOC1_c5KYnEivd5pwlvu78ZfHP34pYb1MIEyWGi3SljnTv5CyLN7m04RPsXND8nlyhN4FTBDe_6qcWZNYhw2AdzHZAjejszCyIw-MCT5le2iWQ4qauFVi1DiAYmuQYeP61hBRzY87z0EQ2wQQUVqeluHbgWlIUb5-i9V5X7l_1oioQhl4dnEmYwIdF3b_QymInLK1-rEIwUU9TX1PlpIbs83poG94gQCoC5P_Yt2s1VmU7it72oaCOiP7IOMNGfxrhcZ0oxjjRlsvrvdUkJAwtCJhdE-YyXegsFK5aUTulSgHn-bl2uv0oURcGkWvGY5NYqn7p-U4GorPzQKePMwDeZTYG0Vtr1EP5n798bR2jHdFvMtrl1ZipU5NSK4x2xy5qD1C_CLfi-pmR4wHaOGLxUD49iT9lwo1_vJB0okjDS0QIc3uK6MNLAPptHuZwmsK8MZ3CI4svKtXkwZe7CZNvSiMIp1vBrC6lUsV5Ync7j5IJ-jExo_rLnPXR_MNZIdZlgshF7y8uzdRECsPIPfUMSy6UL8fn8MVIFilFUDNGPCWJvaH3FKs-UAubsQBelx7d21hI1vz47a2bqyxCtWcHsrGX5FGQyjapPQwbnT8L4kZsK14Ba06RF6dWMdjSPiR7niKcej_bdMpOpzySrpSWNsMqcLgAdYOglJbFL4d-2dgH_Zx5AoRS_Fxn3cfrRAxqqUb8dP7ePtmaQ0msVui1ZJtyMOK8fOyVP2nIk5Llm0NOlBr3WzgWjnc43QMQbjxufi4ukLovFQrDnrzsHKnFqrZmc1Vccy__Wzc3nshTniV7mYDOC_KCnUTLhg.2OVRwtlkM8pSpUdjSyQ0jw\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -174,7 +217,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJlZmYzZDYzYi0wY2QyLTRmNmYtOTJkYS04OGRjZTYzMDA0ZjAiLCJldmVudF9pZCI6IjQ2MDg1YTg0LWNlZWYtNDE5ZS1hYTkyLWVhMTI0NDc3YWE1NiIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM2ODEwOTEsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM3Njc0OTEsImlhdCI6MTYyMzY4MTA5MSwianRpIjoiNDgyYzllZmMtMTUwYS00NzUzLWI0OTctNTk5ZWVmMmY3YTkwIiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiZWZmM2Q2M2ItMGNkMi00ZjZmLTkyZGEtODhkY2U2MzAwNGYwIn0.JQjKf3b5K1hkPParfVDDwjRpg7K9wS3b-Cnbewhoxly2da_IkIxnEAF1BH0ph3jwvfV5QAnKS8mWU48em8xKfdk9injmQcEar9NGsk7jQSedplHlfORsH8uJDUX5zqFH0BjKOi7cVxyr4Y5q59dAZbktri4apkqcv0azv77BkllH8ibCLHFXbiyI2H6daxDpqR3-yMd77qkV-WYxnIeQh64t-dpIx1RNGacUnWJkEN7F22J2hlRdarzgFea_XUkaZqrFAKwAfAMahACQU0m6SmP-7ZQFJgA6OQDA95OVbWzHNFLwmqgJEClUPTk2pDEpY80tUb5Zn1pdysnR_mYvZg",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]
@@ -202,7 +245,7 @@
           "bearer": [
             {
               "key": "token",
-              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiZWEzZGJiMjAtMGQ4Yy00Yzk3LTkyNzctOGIwYWI2OGZiNTdmIiwic3ViIjoiZjY4MzhlMGMtMTBlOC00YWNlLTg3ZmQtMjRhMGY0Mzc4Zjc4IiwiZXZlbnRfaWQiOiI0MGQ2NjYyYy03NWQ3LTQyZjgtOGI3ZC0zMmI3NTg2NDYxMTYiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODUyMzcwLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTM4NzcwLCJpYXQiOjE2MjM4NTIzNzAsImp0aSI6ImU5ZmU4NTEyLThhNTQtNDBhNS04ZjVkLWFhYjRhNmE3NGYwMSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.cSqq_bC4t23JOVp7NkdFCLQFPTud-EMSlvHcPKsmgXw9I43K2Ir0FvzR6D1e2-YFAxcDHkJuqe04gqs3etrqj04DFGMQi04hKrDZGG4q-JLhtgl9b2UIpYCANfqajkctbxdVvmfYDzpOpdggnIjpiPOSg-krx2Sa2CB86yoGHD0LKpwDHryS-V_k7ub5j3qo4i_B65rPiDBcmzaN_iqXDkxIM2yIfbl9Julw1XZj9wYYAV1dzfEdj5rNfUtp-DWXfS-9UcvcSD3bpVoRVLhtoXVOYvRENUpQNoM_yX4LDgU182WxkX_i9NtEp4gwBYRql_Jif44Nr_1Qee86j4SL8g",
+              "value": "{{AccessToken}}",
               "type": "string"
             }
           ]

--- a/lambda_backend/route_microservice/package-lock.json
+++ b/lambda_backend/route_microservice/package-lock.json
@@ -1,8 +1,518 @@
 {
   "name": "route_microservice",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@middy/core": "^2.1.1",
+        "@middy/http-cors": "^2.1.1",
+        "@middy/http-error-handler": "^2.1.1",
+        "@middy/http-event-normalizer": "^2.1.1",
+        "@middy/http-json-body-parser": "^2.1.1",
+        "@middy/http-multipart-body-parser": "^2.1.1",
+        "@middy/http-security-headers": "^2.1.1",
+        "@middy/validator": "^2.1.1",
+        "bad-words": "^3.0.4",
+        "crypto": "^1.0.1",
+        "http-errors": "^1.8.0",
+        "jwt-decode": "^3.1.2"
+      },
+      "devDependencies": {
+        "@types/aws-lambda": "^8.10.76",
+        "@types/aws-sdk": "^2.7.0"
+      }
+    },
+    "node_modules/@middy/core": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-2.1.1.tgz",
+      "integrity": "sha512-c0SIMA2ZYBMXyJrJBiSv9Bieg+BbI0zwny86VDc6UqFD6FNPf9VfFPFoql9xddEbjicCEcIZ9FG5qicSs6zyqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-cors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-2.1.1.tgz",
+      "integrity": "sha512-azUWBZGutiD9Q+ss5JnDXd1KImJ4aiKrGturLcMU1sJtm5+AMEly90KAe7/VQyw1+A8PAML7JQi1BbL+Sj29fQ==",
+      "dependencies": {
+        "@middy/util": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-error-handler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-error-handler/-/http-error-handler-2.1.1.tgz",
+      "integrity": "sha512-VGJAKrP7rveaW4no9szu3ABoV6rpX5wcPLxAyoPw9dHbAkWtzSWpG3GXCRt6xrdoDaopjupgc/nV+SzucWcj1w==",
+      "dependencies": {
+        "@middy/util": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-event-normalizer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-event-normalizer/-/http-event-normalizer-2.1.1.tgz",
+      "integrity": "sha512-9lCcoRPRpuB5pDC+B1YavPdjciqEaIIu+NtEndbWxAJysOlJNOuSTv/0qv27DB1KYyw3ht9nHTSoscZBFmPTFg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-json-body-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-json-body-parser/-/http-json-body-parser-2.1.1.tgz",
+      "integrity": "sha512-cmVAejL59DF27izWDkzrXUdTCGhwGbnZvCICafdn/I40nM3pRQeBHE7pnxXJIOqjysCCQ2SpYWD++rooiaR8aA==",
+      "dependencies": {
+        "http-errors": "1.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-multipart-body-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-multipart-body-parser/-/http-multipart-body-parser-2.1.1.tgz",
+      "integrity": "sha512-y3R9+vGG3pq+sGr3JZKyVdCt3imvXT1Tdyg6F5mpnzRja5/TuGdtRW4lQbP1N7hU3uFPCVKrebFjzMxvJnybSg==",
+      "dependencies": {
+        "busboy": "0.3.1",
+        "http-errors": "1.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-security-headers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-security-headers/-/http-security-headers-2.1.1.tgz",
+      "integrity": "sha512-rubV7PcYh05RRhvho8ptS4BdAdC9rZF36yz8vBruFg8w6nvuD5uw13aYPLaE7yOOv2hQXTZo2ew69sXW5xJ9fQ==",
+      "dependencies": {
+        "@middy/util": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/util": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/util/-/util-2.1.1.tgz",
+      "integrity": "sha512-iz2p9MANA0knsMbntQY5qM62oPdb7BEkRiLAw+yiW1SGCd7jA6shtGOHsMzKUQDqhaStqKBuwFB9+YLvG8noyg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/validator": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/validator/-/validator-2.1.1.tgz",
+      "integrity": "sha512-l6y0x334vGAEYuI3cg2hx4mXJDgrrF4XixOpMWrHGppx30NYGda/xx1/0tJsMk1FiijxWQnbowiUbSeMRmtIng==",
+      "dependencies": {
+        "ajv": "8.1.0",
+        "ajv-formats": "2.0.2",
+        "ajv-formats-draft2019": "1.4.3",
+        "ajv-i18n": "4.0.0",
+        "http-errors": "1.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.76",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.76.tgz",
+      "integrity": "sha512-lCTyeRm3NWqSwDnoji0z82Pl0tsOpr1p+33AiNeidgarloWXh3wdiVRUuxEa+sY9S5YLOYGz5X3N3Zvpibvm5w==",
+      "dev": true
+    },
+    "node_modules/@types/aws-sdk": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/aws-sdk/-/aws-sdk-2.7.0.tgz",
+      "integrity": "sha1-g1iLPRTr3KHUzl4CM4dXdWjOgvM=",
+      "deprecated": "This is a stub types definition for aws-sdk (https://github.com/aws/aws-sdk-js). aws-sdk provides its own type definitions, so you don't need @types/aws-sdk installed!",
+      "dev": true,
+      "dependencies": {
+        "aws-sdk": "*"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+      "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.0.2.tgz",
+      "integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats-draft2019": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ajv-formats-draft2019/-/ajv-formats-draft2019-1.4.3.tgz",
+      "integrity": "sha512-QPZGACI62TyfOg9jhYhXNGRXI/6yZ5bGfv2pT3ldAgg/lFlJk9wZlS6DKsMpApQKG+SJtL75SbCoLdY2xlEhfw==",
+      "dependencies": {
+        "isemail": "^3.2.0",
+        "punycode": "^2.1.1",
+        "schemes": "^1.1.1",
+        "uri-js": "^4.2.2"
+      },
+      "peerDependencies": {
+        "ajv": "*"
+      }
+    },
+    "node_modules/ajv-formats-draft2019/node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ajv-i18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.0.0.tgz",
+      "integrity": "sha512-bZxvSt2PZMBndVlLyhlU5OsqsulV83zwQR8NBiQICQP1SU3gAPXCuRVXcaFS0ZiNBtNLrTGKXK90vtQDAwiMRQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.895.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.895.0.tgz",
+      "integrity": "sha512-f8lkEcItfGaYPhJkdbymLth8K0aZ6aMiuoSr/0r2GaFFLq9neg2WUL0dgqSmVUGf55ZMDbwjcBurhJPrcBbDbw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/bad-words": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
+      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
+      "dependencies": {
+        "badwords-list": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/badwords-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
+      "integrity": "sha1-XphW2/E0gqKVw7CzBK+51M/FxXk="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dependencies": {
+        "dicer": "0.3.0"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/dicer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dependencies": {
+        "streamsearch": "0.1.2"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/http-errors": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "dependencies": {
+        "punycode": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/isemail/node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
+    },
+    "node_modules/schemes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.2.0.tgz",
+      "integrity": "sha512-72r3FcC0YdAZGUIIBvbp+9fc/VpTBKt870aqf5azSJdsaVbjCjZM/e2w3bgt9Xs6sZflE0Txik2ngiIfVcZjkQ==",
+      "dependencies": {
+        "extend": "^3.0.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-js/node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "@middy/core": {
       "version": "2.1.1",
@@ -127,7 +637,8 @@
     "ajv-i18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.0.0.tgz",
-      "integrity": "sha512-bZxvSt2PZMBndVlLyhlU5OsqsulV83zwQR8NBiQICQP1SU3gAPXCuRVXcaFS0ZiNBtNLrTGKXK90vtQDAwiMRQ=="
+      "integrity": "sha512-bZxvSt2PZMBndVlLyhlU5OsqsulV83zwQR8NBiQICQP1SU3gAPXCuRVXcaFS0ZiNBtNLrTGKXK90vtQDAwiMRQ==",
+      "requires": {}
     },
     "aws-sdk": {
       "version": "2.895.0",
@@ -145,6 +656,19 @@
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
       }
+    },
+    "bad-words": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
+      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
+      "requires": {
+        "badwords-list": "^1.0.0"
+      }
+    },
+    "badwords-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
+      "integrity": "sha1-XphW2/E0gqKVw7CzBK+51M/FxXk="
     },
     "base64-js": {
       "version": "1.5.1",

--- a/lambda_backend/route_microservice/package.json
+++ b/lambda_backend/route_microservice/package.json
@@ -17,6 +17,7 @@
     "@middy/http-multipart-body-parser": "^2.1.1",
     "@middy/http-security-headers": "^2.1.1",
     "@middy/validator": "^2.1.1",
+    "bad-words": "^3.0.4",
     "crypto": "^1.0.1",
     "http-errors": "^1.8.0",
     "jwt-decode": "^3.1.2"

--- a/lambda_backend/route_microservice/serverless.yml
+++ b/lambda_backend/route_microservice/serverless.yml
@@ -98,11 +98,11 @@ functions:
           cors:
             origin: ${self:custom._origin.${self:custom.stage}}
 
-  upVoteRoute:
-    handler: src/upVoteRoute.handler
+  upvoteRoute:
+    handler: src/upvoteRoute.handler
     events:
       - http:
-          path: route/details/vote
+          path: route/details/upvote
           method: post
           cors:
             origin: ${self:custom._origin.${self:custom.stage}}

--- a/lambda_backend/route_microservice/src/addComment.ts
+++ b/lambda_backend/route_microservice/src/addComment.ts
@@ -1,15 +1,13 @@
 import { Handler } from 'aws-lambda';
 import DynamoDB, { AttributeValue, UpdateItemInput } from 'aws-sdk/clients/dynamodb';
-import {
-  getMiddlewareAddedHandler,
-  getItemFromRouteTable,
-  addCommentSchema,
-  AddCommentEvent,
-  Comment,
-  JwtPayload,
-} from './common';
 import jwt_decode from 'jwt-decode';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getItemFromRouteTable } from './common/db';
+import { addCommentSchema } from './common/schema';
+import { AddCommentEvent, Comment, JwtPayload } from './common/types';
+import { cleanBadwords } from './common/badwords';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 
@@ -30,7 +28,7 @@ const addComment: Handler = async (event: AddCommentEvent) => {
   const newComment: Comment = {
     username,
     timestamp: Date.now(),
-    comment: commentStr,
+    comment: cleanBadwords(commentStr),
   };
   comments = [...comments, newComment];
 

--- a/lambda_backend/route_microservice/src/addComment.ts
+++ b/lambda_backend/route_microservice/src/addComment.ts
@@ -7,7 +7,7 @@ import { getMiddlewareAddedHandler } from './common/middleware';
 import { getItemFromRouteTable } from './common/db';
 import { addCommentSchema } from './common/schema';
 import { AddCommentEvent, Comment, JwtPayload } from './common/types';
-import { cleanBadwords } from './common/badwords';
+import { cleanBadWords } from './common/badwords';
 import { COMMENT_LIMIT } from './config';
 
 const dynamoDb = new DynamoDB.DocumentClient();
@@ -39,7 +39,7 @@ const addComment: Handler = async (event: AddCommentEvent) => {
   const newComment: Comment = {
     username,
     timestamp: Date.now(),
-    comment: cleanBadwords(commentStr),
+    comment: cleanBadWords(commentStr),
   };
   comments = [...comments, newComment];
 

--- a/lambda_backend/route_microservice/src/addComment.ts
+++ b/lambda_backend/route_microservice/src/addComment.ts
@@ -49,7 +49,7 @@ const addComment: Handler = async (event: AddCommentEvent) => {
   try {
     await dynamoDb.update(updateItemInput).promise();
   } catch (error) {
-    throw createError(500, 'Error updating item :' + error.stack);
+    throw createError(500, 'Error updating item', error);
   }
 
   return {

--- a/lambda_backend/route_microservice/src/common/badwords.ts
+++ b/lambda_backend/route_microservice/src/common/badwords.ts
@@ -2,6 +2,6 @@ import Filter from 'bad-words';
 
 const filter = new Filter();
 
-export const cleanBadwords = (str: string): string => {
+export const cleanBadWords = (str: string): string => {
   return filter.clean(str);
 };

--- a/lambda_backend/route_microservice/src/common/badwords.ts
+++ b/lambda_backend/route_microservice/src/common/badwords.ts
@@ -1,0 +1,7 @@
+import Filter from 'bad-words';
+
+const filter = new Filter();
+
+export const cleanBadwords = (str: string): string => {
+  return filter.clean(str);
+};

--- a/lambda_backend/route_microservice/src/common/cognito.ts
+++ b/lambda_backend/route_microservice/src/common/cognito.ts
@@ -3,6 +3,7 @@ import CognitoIdentityServiceProvider, {
   AttributeType,
   GetUserRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
+import { CognitoUserDetails, UserRole } from './types';
 import createError from 'http-errors';
 
 const cognitoIdentity = new CognitoIdentityServiceProvider();
@@ -38,10 +39,3 @@ const parseUserAttributes = (UserAttributes: AttributeType[]): CognitoUserDetail
     .Value as UserRole;
   return { userEmail, userRole };
 };
-
-interface CognitoUserDetails {
-  userEmail: string;
-  userRole: UserRole;
-}
-
-type UserRole = 'admin' | 'user';

--- a/lambda_backend/route_microservice/src/common/cognito.ts
+++ b/lambda_backend/route_microservice/src/common/cognito.ts
@@ -5,8 +5,6 @@ import CognitoIdentityServiceProvider, {
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
 import createError from 'http-errors';
 
-import { CognitoUserDetails } from './types';
-
 const cognitoIdentity = new CognitoIdentityServiceProvider();
 
 export const getCognitoUserDetails = async (AccessToken: string): Promise<CognitoUserDetails> => {
@@ -36,5 +34,12 @@ export const adminGetCognitoUserDetails = async (Username: string): Promise<Cogn
 const parseUserAttributes = (UserAttributes: AttributeType[]): CognitoUserDetails => {
   const userEmail = UserAttributes.filter((attribute) => attribute.Name === 'email')[0]
     .Value as string;
-  return { userEmail };
+  const userRole = UserAttributes.filter((attribute) => attribute.Name === 'custom:role')[0]
+    .Value as 'admin' | 'user';
+  return { userEmail, userRole };
 };
+
+interface CognitoUserDetails {
+  userEmail: string;
+  userRole: 'admin' | 'user';
+}

--- a/lambda_backend/route_microservice/src/common/cognito.ts
+++ b/lambda_backend/route_microservice/src/common/cognito.ts
@@ -35,11 +35,13 @@ const parseUserAttributes = (UserAttributes: AttributeType[]): CognitoUserDetail
   const userEmail = UserAttributes.filter((attribute) => attribute.Name === 'email')[0]
     .Value as string;
   const userRole = UserAttributes.filter((attribute) => attribute.Name === 'custom:role')[0]
-    .Value as 'admin' | 'user';
+    .Value as UserRole;
   return { userEmail, userRole };
 };
 
 interface CognitoUserDetails {
   userEmail: string;
-  userRole: 'admin' | 'user';
+  userRole: UserRole;
 }
+
+type UserRole = 'admin' | 'user';

--- a/lambda_backend/route_microservice/src/common/db.ts
+++ b/lambda_backend/route_microservice/src/common/db.ts
@@ -20,7 +20,7 @@ export const getItemFromRouteTable = async (
   try {
     ({ Item } = await dynamoDb.get(getItemInput).promise());
   } catch (error) {
-    throw createError(500, 'Error getting item :' + error.stack);
+    throw createError(500, 'Error getting item', error);
   }
   if (!Item) {
     throw createError(400, 'Route does not exist');
@@ -45,7 +45,7 @@ export const getGymIsRegistered = async (
   try {
     ({ Items } = await dynamoDb.query(queryInput).promise());
   } catch (error) {
-    throw createError(500, 'Error querying table :' + error.stack);
+    throw createError(500, 'Error querying table', error);
   }
   return Items.length > 0;
 };

--- a/lambda_backend/route_microservice/src/common/index.ts
+++ b/lambda_backend/route_microservice/src/common/index.ts
@@ -1,5 +1,0 @@
-export * from './types';
-export * from './schema';
-export * from './middleware';
-export * from './db';
-export * from './cognito';

--- a/lambda_backend/route_microservice/src/common/schema.ts
+++ b/lambda_backend/route_microservice/src/common/schema.ts
@@ -1,6 +1,6 @@
 const ISODateStringPattern =
   '^\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z$';
-const AlphanumericSpaceHyphen = '^[a-zA-Z0-9 \\-]*$';
+const AlphanumericSpace = '^[a-zA-Z0-9 ]*$';
 const CapitalizedAlphabets = '^[A-Z]*$';
 const NumericDecimalCommaSpace = '^[0-9., ]*$';
 const AsciiCharacters = '^[ -~]+$';
@@ -18,8 +18,8 @@ export const createRouteSchema = {
         },
         routeName: {
           type: 'string',
-          maxLength: 50,
-          pattern: AlphanumericSpaceHyphen,
+          maxLength: 30,
+          pattern: AsciiCharacters,
         },
         expiredTime: {
           type: 'string',
@@ -68,7 +68,7 @@ export const deleteRouteSchema = {
       properties: {
         username: {
           type: 'string',
-          pattern: AlphanumericSpaceHyphen,
+          pattern: AlphanumericSpace,
         },
         createdAt: {
           type: 'string',
@@ -88,7 +88,7 @@ export const getRouteDetailsSchema = {
       properties: {
         username: {
           type: 'string',
-          pattern: AlphanumericSpaceHyphen,
+          pattern: AlphanumericSpace,
         },
         createdAt: {
           type: 'string',
@@ -145,7 +145,7 @@ export const deleteCommentSchema = {
         ...getRouteDetailsSchema.properties.body.properties,
         commentUsername: {
           type: 'string',
-          pattern: AlphanumericSpaceHyphen,
+          pattern: AlphanumericSpace,
         },
         timestamp: { type: 'number' },
       },

--- a/lambda_backend/route_microservice/src/common/schema.ts
+++ b/lambda_backend/route_microservice/src/common/schema.ts
@@ -100,7 +100,7 @@ export const getRouteDetailsSchema = {
   },
 };
 
-export const upVoteRouteSchema = getRouteDetailsSchema;
+export const upvoteRouteSchema = getRouteDetailsSchema;
 
 export const reportRouteSchema = getRouteDetailsSchema;
 

--- a/lambda_backend/route_microservice/src/common/types.ts
+++ b/lambda_backend/route_microservice/src/common/types.ts
@@ -131,3 +131,10 @@ export interface RequestGymEvent extends AuthHeader {
     gymName: string;
   };
 }
+
+export interface CognitoUserDetails {
+  userEmail: string;
+  userRole: UserRole;
+}
+
+export type UserRole = 'admin' | 'user';

--- a/lambda_backend/route_microservice/src/common/types.ts
+++ b/lambda_backend/route_microservice/src/common/types.ts
@@ -124,10 +124,6 @@ export interface RouteItem {
   comments: Array<Comment>;
 }
 
-export interface CognitoUserDetails {
-  userEmail: string;
-}
-
 export interface RequestGymEvent extends AuthHeader {
   body: {
     countryCode: string;

--- a/lambda_backend/route_microservice/src/common/types.ts
+++ b/lambda_backend/route_microservice/src/common/types.ts
@@ -48,14 +48,14 @@ export interface GetRouteDetailsEvent {
   };
 }
 
-export interface UpVoteRouteEvent extends AuthHeader {
+export interface UpvoteRouteEvent extends AuthHeader {
   body: {
     username: string;
     createdAt: string;
   };
 }
 
-export type ReportRouteEvent = UpVoteRouteEvent;
+export type ReportRouteEvent = UpvoteRouteEvent;
 
 export interface GradeRouteEvent extends AuthHeader {
   body: {
@@ -118,7 +118,7 @@ export interface RouteItem {
   publicGrade: number;
   publicGradeSubmissions: Array<GradeSubmission>;
   voteCount: number;
-  upVotes: Array<string>;
+  upvotes: Array<string>;
   reports: Array<string>;
   commentCount: number;
   comments: Array<Comment>;

--- a/lambda_backend/route_microservice/src/config.ts
+++ b/lambda_backend/route_microservice/src/config.ts
@@ -1,1 +1,2 @@
 export const MAX_PHOTO_SIZE = 5242880; // 5MB
+export const COMMENT_LIMIT = 1;

--- a/lambda_backend/route_microservice/src/createRoute.ts
+++ b/lambda_backend/route_microservice/src/createRoute.ts
@@ -9,7 +9,7 @@ import { getMiddlewareAddedHandler } from './common/middleware';
 import { getGymIsRegistered } from './common/db';
 import { createRouteSchema } from './common/schema';
 import { CreateRouteEvent, RouteItem, JwtPayload } from './common/types';
-import { cleanBadwords } from './common/badwords';
+import { cleanBadWords } from './common/badwords';
 import { MAX_PHOTO_SIZE } from './config';
 
 const dynamoDb = new DynamoDB.DocumentClient();
@@ -71,14 +71,14 @@ const createRoute: Handler = async (event: CreateRouteEvent) => {
     username,
     createdAt,
     ttl: new Date(expiredTime).getTime(),
-    routeName: cleanBadwords(routeName),
+    routeName: cleanBadWords(routeName),
     gymLocation,
     routeURL,
     ownerGrade,
     publicGrade: ownerGrade,
     publicGradeSubmissions: [{ username, grade: ownerGrade }],
     voteCount: 0,
-    upVotes: [],
+    upvotes: [],
     reports: [],
     commentCount: 0,
     comments: [],

--- a/lambda_backend/route_microservice/src/createRoute.ts
+++ b/lambda_backend/route_microservice/src/createRoute.ts
@@ -1,19 +1,16 @@
 import { Handler } from 'aws-lambda';
 import DynamoDB, { PutItemInput, AttributeMap } from 'aws-sdk/clients/dynamodb';
 import S3, { PutObjectRequest } from 'aws-sdk/clients/s3';
-
-import {
-  getMiddlewareAddedHandler,
-  getGymIsRegistered,
-  CreateRouteEvent,
-  createRouteSchema,
-  JwtPayload,
-  RouteItem,
-} from './common';
-import { MAX_PHOTO_SIZE } from './config';
 import { createHash } from 'crypto';
 import jwt_decode from 'jwt-decode';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getGymIsRegistered } from './common/db';
+import { createRouteSchema } from './common/schema';
+import { CreateRouteEvent, RouteItem, JwtPayload } from './common/types';
+import { cleanBadwords } from './common/badwords';
+import { MAX_PHOTO_SIZE } from './config';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 const s3 = new S3();
@@ -68,7 +65,7 @@ const createRoute: Handler = async (event: CreateRouteEvent) => {
     username,
     createdAt,
     ttl: new Date(expiredTime).getTime(),
-    routeName,
+    routeName: cleanBadwords(routeName),
     gymLocation,
     routeURL,
     ownerGrade,

--- a/lambda_backend/route_microservice/src/createRoute.ts
+++ b/lambda_backend/route_microservice/src/createRoute.ts
@@ -30,10 +30,16 @@ const createRoute: Handler = async (event: CreateRouteEvent) => {
 
   const { content, mimetype } = routePhoto;
   if (mimetype !== 'image/jpeg') {
-    throw createError(400, 'Only JPEG is accepted');
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ Message: 'Invalid image type' }),
+    };
   }
   if (content.byteLength > MAX_PHOTO_SIZE) {
-    throw createError(400, 'Max allowed size is 5MB');
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ Message: 'Invalid file size' }),
+    };
   }
   const gymIsRegistered = await getGymIsRegistered(countryCode, gymLocation);
   if (!gymIsRegistered) {
@@ -58,7 +64,7 @@ const createRoute: Handler = async (event: CreateRouteEvent) => {
   try {
     ({ Location: routeURL } = await s3.upload(putObjectRequest).promise());
   } catch (error) {
-    throw createError(500, 'S3 upload failed.' + error.stack);
+    throw createError(500, 'S3 upload failed', error);
   }
 
   const routeItem: RouteItem = {
@@ -84,7 +90,7 @@ const createRoute: Handler = async (event: CreateRouteEvent) => {
   try {
     await dynamoDb.put(putItemInput).promise();
   } catch (error) {
-    throw createError(500, 'DB put operation failed: ' + error.stack);
+    throw createError(500, 'DB put operation failed', error);
   }
   return {
     statusCode: 201,

--- a/lambda_backend/route_microservice/src/createRoute.ts
+++ b/lambda_backend/route_microservice/src/createRoute.ts
@@ -32,7 +32,7 @@ const createRoute: Handler = async (event: CreateRouteEvent) => {
   if (mimetype !== 'image/jpeg') {
     return {
       statusCode: 400,
-      body: JSON.stringify({ Message: 'Invalid image type' }),
+      body: JSON.stringify({ Message: 'Invalid file type' }),
     };
   }
   if (content.byteLength > MAX_PHOTO_SIZE) {

--- a/lambda_backend/route_microservice/src/deleteComment.ts
+++ b/lambda_backend/route_microservice/src/deleteComment.ts
@@ -1,14 +1,12 @@
 import { Handler } from 'aws-lambda';
 import DynamoDB, { AttributeValue, UpdateItemInput } from 'aws-sdk/clients/dynamodb';
-import {
-  getMiddlewareAddedHandler,
-  DeleteCommentEvent,
-  deleteCommentSchema,
-  JwtPayload,
-  getItemFromRouteTable,
-} from './common';
 import jwt_decode from 'jwt-decode';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getItemFromRouteTable } from './common/db';
+import { deleteCommentSchema } from './common/schema';
+import { DeleteCommentEvent, JwtPayload } from './common/types';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 

--- a/lambda_backend/route_microservice/src/deleteComment.ts
+++ b/lambda_backend/route_microservice/src/deleteComment.ts
@@ -60,7 +60,7 @@ const deleteComment: Handler = async (event: DeleteCommentEvent) => {
   try {
     await dynamoDb.update(updateItemInput).promise();
   } catch (error) {
-    throw createError(500, 'Error updating item :' + error.stack);
+    throw createError(500, 'Error updating item', error);
   }
 
   return {

--- a/lambda_backend/route_microservice/src/deleteRoute.ts
+++ b/lambda_backend/route_microservice/src/deleteRoute.ts
@@ -50,7 +50,7 @@ const deleteRoute: Handler = async (event: DeleteRouteEvent) => {
   try {
     await s3.deleteObject(deleteObjectRequest).promise();
   } catch (error) {
-    throw createError(500, 'S3 deletion failed.' + error.stack);
+    throw createError(500, 'S3 deletion failed', error);
   }
 
   const deleteItemInput: DeleteItemInput = {
@@ -63,7 +63,7 @@ const deleteRoute: Handler = async (event: DeleteRouteEvent) => {
   try {
     await dynamoDb.delete(deleteItemInput).promise();
   } catch (error) {
-    throw createError(500, 'DB delete operation failed: ' + error.stack);
+    throw createError(500, 'DB delete operation failed', error);
   }
 
   return {

--- a/lambda_backend/route_microservice/src/deleteRoute.ts
+++ b/lambda_backend/route_microservice/src/deleteRoute.ts
@@ -1,17 +1,14 @@
 import { Handler } from 'aws-lambda';
 import DynamoDB, { AttributeValue, DeleteItemInput } from 'aws-sdk/clients/dynamodb';
 import S3, { DeleteObjectRequest } from 'aws-sdk/clients/s3';
-
-import {
-  getMiddlewareAddedHandler,
-  DeleteRouteEvent,
-  deleteRouteSchema,
-  JwtPayload,
-  getItemFromRouteTable,
-} from './common';
-import { createHash } from 'crypto';
 import jwt_decode from 'jwt-decode';
 import createError from 'http-errors';
+import { createHash } from 'crypto';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getItemFromRouteTable } from './common/db';
+import { deleteRouteSchema } from './common/schema';
+import { DeleteRouteEvent, JwtPayload } from './common/types';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 const s3 = new S3();

--- a/lambda_backend/route_microservice/src/getAllGyms.ts
+++ b/lambda_backend/route_microservice/src/getAllGyms.ts
@@ -36,7 +36,7 @@ const getAllGyms: Handler = async (event: GetAllGymsEvent) => {
         body: JSON.stringify({ Message: 'Query all gyms success', Items }),
       };
     } catch (error) {
-      throw createError(500, 'Error querying table :' + error.stack);
+      throw createError(500, 'Error querying table', error);
     }
   } else {
     const scanInput: ScanInput = {
@@ -64,7 +64,7 @@ const getAllGyms: Handler = async (event: GetAllGymsEvent) => {
         body: JSON.stringify({ Message: 'Scan all gyms success', Items }),
       };
     } catch (error) {
-      throw createError(500, 'Error scanning table :' + error.stack);
+      throw createError(500, 'Error scanning table', error);
     }
   }
 };

--- a/lambda_backend/route_microservice/src/getAllGyms.ts
+++ b/lambda_backend/route_microservice/src/getAllGyms.ts
@@ -5,8 +5,10 @@ import DynamoDB, {
   QueryInput,
   ItemList,
 } from 'aws-sdk/clients/dynamodb';
-import { getMiddlewareAddedHandler, GetAllGymsEvent } from './common';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { GetAllGymsEvent } from './common/types';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 

--- a/lambda_backend/route_microservice/src/getRouteDetails.ts
+++ b/lambda_backend/route_microservice/src/getRouteDetails.ts
@@ -1,13 +1,11 @@
 import { Handler } from 'aws-lambda';
-import {
-  getItemFromRouteTable,
-  getMiddlewareAddedHandler,
-  GetRouteDetailsEvent,
-  getRouteDetailsSchema,
-  JwtPayload,
-} from './common';
 import jwt_decode from 'jwt-decode';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getItemFromRouteTable } from './common/db';
+import { getRouteDetailsSchema } from './common/schema';
+import { GetRouteDetailsEvent, JwtPayload } from './common/types';
 
 const getRouteDetails: Handler = async (event: GetRouteDetailsEvent) => {
   if (!process.env['ROUTE_TABLE_NAME'] || !process.env['COGNITO_USERPOOL_ID']) {

--- a/lambda_backend/route_microservice/src/getRouteDetails.ts
+++ b/lambda_backend/route_microservice/src/getRouteDetails.ts
@@ -31,7 +31,7 @@ const getRouteDetails: Handler = async (event: GetRouteDetailsEvent) => {
     publicGrade,
     publicGradeSubmissions,
     voteCount,
-    upVotes,
+    upvotes,
     reports,
     comments,
   } = Item;
@@ -43,7 +43,7 @@ const getRouteDetails: Handler = async (event: GetRouteDetailsEvent) => {
         graded = grade;
       }
     });
-    upVotes.forEach((name) => {
+    upvotes.forEach((name) => {
       if (name === username) {
         hasVoted = true;
       }

--- a/lambda_backend/route_microservice/src/getRoutesByGym.ts
+++ b/lambda_backend/route_microservice/src/getRoutesByGym.ts
@@ -1,7 +1,9 @@
 import { Handler } from 'aws-lambda';
 import DynamoDB, { AttributeValue, QueryInput } from 'aws-sdk/clients/dynamodb';
-import { getMiddlewareAddedHandler, GetRoutesByGymEvent } from './common';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { GetRoutesByGymEvent } from './common/types';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 

--- a/lambda_backend/route_microservice/src/getRoutesByGym.ts
+++ b/lambda_backend/route_microservice/src/getRoutesByGym.ts
@@ -31,7 +31,7 @@ const getRoutesByGym: Handler = async (event: GetRoutesByGymEvent) => {
       body: JSON.stringify({ Message: 'Query routes by gym success', Items }),
     };
   } catch (error) {
-    throw createError(500, 'Error querying table :' + error.stack);
+    throw createError(500, 'Error querying table', error);
   }
 };
 

--- a/lambda_backend/route_microservice/src/gradeRoute.ts
+++ b/lambda_backend/route_microservice/src/gradeRoute.ts
@@ -1,14 +1,12 @@
 import { Handler } from 'aws-lambda';
 import DynamoDB, { AttributeValue, UpdateItemInput } from 'aws-sdk/clients/dynamodb';
-import {
-  getMiddlewareAddedHandler,
-  GradeRouteEvent,
-  gradeRouteSchema,
-  JwtPayload,
-  getItemFromRouteTable,
-} from './common';
 import jwt_decode from 'jwt-decode';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getItemFromRouteTable } from './common/db';
+import { gradeRouteSchema } from './common/schema';
+import { GradeRouteEvent, JwtPayload } from './common/types';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 

--- a/lambda_backend/route_microservice/src/gradeRoute.ts
+++ b/lambda_backend/route_microservice/src/gradeRoute.ts
@@ -60,7 +60,7 @@ const gradeRoute: Handler = async (event: GradeRouteEvent) => {
   try {
     await dynamoDb.update(updateItemInput).promise();
   } catch (error) {
-    throw createError(500, 'Error updating item :' + error.stack);
+    throw createError(500, 'Error updating item', error);
   }
 
   return {

--- a/lambda_backend/route_microservice/src/reportRoute.ts
+++ b/lambda_backend/route_microservice/src/reportRoute.ts
@@ -43,7 +43,7 @@ const reportRoute: Handler = async (event: ReportRouteEvent) => {
     try {
       await dynamoDb.update(updateItemInput).promise();
     } catch (error) {
-      throw createError(500, 'Error updating item :' + error.stack);
+      throw createError(500, 'Error updating item', error);
     }
 
     const publishInput: PublishInput = {
@@ -53,7 +53,7 @@ const reportRoute: Handler = async (event: ReportRouteEvent) => {
     try {
       await SNSInstance.publish(publishInput).promise();
     } catch (error) {
-      throw createError(500, 'Error publishing SNS :' + error.stack);
+      throw createError(500, 'Error publishing SNS', error);
     }
 
     return {

--- a/lambda_backend/route_microservice/src/reportRoute.ts
+++ b/lambda_backend/route_microservice/src/reportRoute.ts
@@ -1,14 +1,12 @@
 import { Handler } from 'aws-lambda';
 import DynamoDB, { AttributeValue, UpdateItemInput } from 'aws-sdk/clients/dynamodb';
-import {
-  getMiddlewareAddedHandler,
-  ReportRouteEvent,
-  reportRouteSchema,
-  JwtPayload,
-  getItemFromRouteTable,
-} from './common';
 import jwt_decode from 'jwt-decode';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getItemFromRouteTable } from './common/db';
+import { reportRouteSchema } from './common/schema';
+import { ReportRouteEvent, JwtPayload } from './common/types';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 

--- a/lambda_backend/route_microservice/src/requestGym.ts
+++ b/lambda_backend/route_microservice/src/requestGym.ts
@@ -1,12 +1,11 @@
 import { Handler } from 'aws-lambda';
 import SNS, { PublishInput } from 'aws-sdk/clients/sns';
-import {
-  getMiddlewareAddedHandler,
-  getCognitoUserDetails,
-  RequestGymEvent,
-  requestGymSchema,
-} from './common';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getCognitoUserDetails } from './common/cognito';
+import { requestGymSchema } from './common/schema';
+import { RequestGymEvent } from './common/types';
 
 const SNSInstance = new SNS();
 

--- a/lambda_backend/route_microservice/src/requestGym.ts
+++ b/lambda_backend/route_microservice/src/requestGym.ts
@@ -27,7 +27,7 @@ const requestGym: Handler = async (event: RequestGymEvent) => {
   try {
     await SNSInstance.publish(publishInput).promise();
   } catch (error) {
-    throw createError(500, 'Error publishing SNS :' + error.stack);
+    throw createError(500, 'Error publishing SNS', error);
   }
 
   return {

--- a/lambda_backend/route_microservice/src/upVoteRoute.ts
+++ b/lambda_backend/route_microservice/src/upVoteRoute.ts
@@ -1,14 +1,12 @@
 import { Handler } from 'aws-lambda';
 import DynamoDB, { AttributeValue, UpdateItemInput } from 'aws-sdk/clients/dynamodb';
-import {
-  getMiddlewareAddedHandler,
-  UpVoteRouteEvent,
-  upVoteRouteSchema,
-  JwtPayload,
-  getItemFromRouteTable,
-} from './common';
 import jwt_decode from 'jwt-decode';
 import createError from 'http-errors';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { getItemFromRouteTable } from './common/db';
+import { upVoteRouteSchema } from './common/schema';
+import { UpVoteRouteEvent, JwtPayload } from './common/types';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 

--- a/lambda_backend/route_microservice/src/upVoteRoute.ts
+++ b/lambda_backend/route_microservice/src/upVoteRoute.ts
@@ -5,12 +5,12 @@ import createError from 'http-errors';
 
 import { getMiddlewareAddedHandler } from './common/middleware';
 import { getItemFromRouteTable } from './common/db';
-import { upVoteRouteSchema } from './common/schema';
-import { UpVoteRouteEvent, JwtPayload } from './common/types';
+import { upvoteRouteSchema } from './common/schema';
+import { UpvoteRouteEvent, JwtPayload } from './common/types';
 
 const dynamoDb = new DynamoDB.DocumentClient();
 
-const upVoteRoute: Handler = async (event: UpVoteRouteEvent) => {
+const upvoteRoute: Handler = async (event: UpvoteRouteEvent) => {
   if (!process.env['ROUTE_TABLE_NAME']) {
     throw createError(500, 'Route table name is not set');
   }
@@ -22,19 +22,19 @@ const upVoteRoute: Handler = async (event: UpVoteRouteEvent) => {
   const Item = await getItemFromRouteTable(routeOwnerUsername, createdAt);
 
   const { username } = (await jwt_decode(Authorization.split(' ')[1])) as JwtPayload;
-  const { upVotes } = Item;
-  if (!upVotes.includes(username)) {
-    upVotes.push(username);
+  const { upvotes } = Item;
+  if (!upvotes.includes(username)) {
+    upvotes.push(username);
     const updateItemInput: UpdateItemInput = {
       TableName: process.env['ROUTE_TABLE_NAME'],
       Key: {
         username: routeOwnerUsername as AttributeValue,
         createdAt: createdAt as AttributeValue,
       },
-      UpdateExpression: 'SET upVotes = :upVotes, voteCount = :voteCount',
+      UpdateExpression: 'SET upvotes = :upvotes, voteCount = :voteCount',
       ExpressionAttributeValues: {
-        ':upVotes': upVotes as AttributeValue,
-        ':voteCount': upVotes.length as AttributeValue,
+        ':upvotes': upvotes as AttributeValue,
+        ':voteCount': upvotes.length as AttributeValue,
       },
     };
     try {
@@ -49,4 +49,4 @@ const upVoteRoute: Handler = async (event: UpVoteRouteEvent) => {
   };
 };
 
-export const handler = getMiddlewareAddedHandler(upVoteRoute, upVoteRouteSchema);
+export const handler = getMiddlewareAddedHandler(upvoteRoute, upvoteRouteSchema);

--- a/lambda_backend/route_microservice/src/upVoteRoute.ts
+++ b/lambda_backend/route_microservice/src/upVoteRoute.ts
@@ -40,7 +40,7 @@ const upVoteRoute: Handler = async (event: UpVoteRouteEvent) => {
     try {
       await dynamoDb.update(updateItemInput).promise();
     } catch (error) {
-      throw createError(500, 'Error updating item :' + error.stack);
+      throw createError(500, 'Error updating item', error);
     }
   }
   return {

--- a/lambda_backend/user_microservice/package-lock.json
+++ b/lambda_backend/user_microservice/package-lock.json
@@ -1,8 +1,449 @@
 {
   "name": "user_microservice",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@middy/core": "^2.1.1",
+        "@middy/http-cors": "^2.1.1",
+        "@middy/http-error-handler": "^2.1.1",
+        "@middy/http-json-body-parser": "^2.1.1",
+        "@middy/http-security-headers": "^2.1.1",
+        "@middy/validator": "^2.1.1",
+        "crypto": "^1.0.1",
+        "http-errors": "^1.8.0",
+        "jwt-decode": "^3.1.2"
+      },
+      "devDependencies": {
+        "@types/aws-lambda": "^8.10.76",
+        "@types/aws-sdk": "^2.7.0"
+      }
+    },
+    "node_modules/@middy/core": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-2.1.1.tgz",
+      "integrity": "sha512-c0SIMA2ZYBMXyJrJBiSv9Bieg+BbI0zwny86VDc6UqFD6FNPf9VfFPFoql9xddEbjicCEcIZ9FG5qicSs6zyqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-cors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-2.1.1.tgz",
+      "integrity": "sha512-azUWBZGutiD9Q+ss5JnDXd1KImJ4aiKrGturLcMU1sJtm5+AMEly90KAe7/VQyw1+A8PAML7JQi1BbL+Sj29fQ==",
+      "dependencies": {
+        "@middy/util": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-error-handler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-error-handler/-/http-error-handler-2.1.1.tgz",
+      "integrity": "sha512-VGJAKrP7rveaW4no9szu3ABoV6rpX5wcPLxAyoPw9dHbAkWtzSWpG3GXCRt6xrdoDaopjupgc/nV+SzucWcj1w==",
+      "dependencies": {
+        "@middy/util": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-json-body-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-json-body-parser/-/http-json-body-parser-2.1.1.tgz",
+      "integrity": "sha512-cmVAejL59DF27izWDkzrXUdTCGhwGbnZvCICafdn/I40nM3pRQeBHE7pnxXJIOqjysCCQ2SpYWD++rooiaR8aA==",
+      "dependencies": {
+        "http-errors": "1.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/http-security-headers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/http-security-headers/-/http-security-headers-2.1.1.tgz",
+      "integrity": "sha512-rubV7PcYh05RRhvho8ptS4BdAdC9rZF36yz8vBruFg8w6nvuD5uw13aYPLaE7yOOv2hQXTZo2ew69sXW5xJ9fQ==",
+      "dependencies": {
+        "@middy/util": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/util": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/util/-/util-2.1.1.tgz",
+      "integrity": "sha512-iz2p9MANA0knsMbntQY5qM62oPdb7BEkRiLAw+yiW1SGCd7jA6shtGOHsMzKUQDqhaStqKBuwFB9+YLvG8noyg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@middy/validator": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@middy/validator/-/validator-2.1.1.tgz",
+      "integrity": "sha512-l6y0x334vGAEYuI3cg2hx4mXJDgrrF4XixOpMWrHGppx30NYGda/xx1/0tJsMk1FiijxWQnbowiUbSeMRmtIng==",
+      "dependencies": {
+        "ajv": "8.1.0",
+        "ajv-formats": "2.0.2",
+        "ajv-formats-draft2019": "1.4.3",
+        "ajv-i18n": "4.0.0",
+        "http-errors": "1.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.76",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.76.tgz",
+      "integrity": "sha512-lCTyeRm3NWqSwDnoji0z82Pl0tsOpr1p+33AiNeidgarloWXh3wdiVRUuxEa+sY9S5YLOYGz5X3N3Zvpibvm5w==",
+      "dev": true
+    },
+    "node_modules/@types/aws-sdk": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/aws-sdk/-/aws-sdk-2.7.0.tgz",
+      "integrity": "sha1-g1iLPRTr3KHUzl4CM4dXdWjOgvM=",
+      "deprecated": "This is a stub types definition for aws-sdk (https://github.com/aws/aws-sdk-js). aws-sdk provides its own type definitions, so you don't need @types/aws-sdk installed!",
+      "dev": true,
+      "dependencies": {
+        "aws-sdk": "*"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+      "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.0.2.tgz",
+      "integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats-draft2019": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ajv-formats-draft2019/-/ajv-formats-draft2019-1.4.3.tgz",
+      "integrity": "sha512-QPZGACI62TyfOg9jhYhXNGRXI/6yZ5bGfv2pT3ldAgg/lFlJk9wZlS6DKsMpApQKG+SJtL75SbCoLdY2xlEhfw==",
+      "dependencies": {
+        "isemail": "^3.2.0",
+        "punycode": "^2.1.1",
+        "schemes": "^1.1.1",
+        "uri-js": "^4.2.2"
+      },
+      "peerDependencies": {
+        "ajv": "*"
+      }
+    },
+    "node_modules/ajv-formats-draft2019/node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ajv-i18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.0.0.tgz",
+      "integrity": "sha512-bZxvSt2PZMBndVlLyhlU5OsqsulV83zwQR8NBiQICQP1SU3gAPXCuRVXcaFS0ZiNBtNLrTGKXK90vtQDAwiMRQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.895.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.895.0.tgz",
+      "integrity": "sha512-f8lkEcItfGaYPhJkdbymLth8K0aZ6aMiuoSr/0r2GaFFLq9neg2WUL0dgqSmVUGf55ZMDbwjcBurhJPrcBbDbw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/http-errors": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "dependencies": {
+        "punycode": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/isemail/node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
+    },
+    "node_modules/schemes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.2.0.tgz",
+      "integrity": "sha512-72r3FcC0YdAZGUIIBvbp+9fc/VpTBKt870aqf5azSJdsaVbjCjZM/e2w3bgt9Xs6sZflE0Txik2ngiIfVcZjkQ==",
+      "dependencies": {
+        "extend": "^3.0.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-js/node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "@middy/core": {
       "version": "2.1.1",
@@ -113,7 +554,8 @@
     "ajv-i18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.0.0.tgz",
-      "integrity": "sha512-bZxvSt2PZMBndVlLyhlU5OsqsulV83zwQR8NBiQICQP1SU3gAPXCuRVXcaFS0ZiNBtNLrTGKXK90vtQDAwiMRQ=="
+      "integrity": "sha512-bZxvSt2PZMBndVlLyhlU5OsqsulV83zwQR8NBiQICQP1SU3gAPXCuRVXcaFS0ZiNBtNLrTGKXK90vtQDAwiMRQ==",
+      "requires": {}
     },
     "aws-sdk": {
       "version": "2.895.0",
@@ -229,6 +671,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "punycode": {
       "version": "1.3.2",

--- a/lambda_backend/user_microservice/package.json
+++ b/lambda_backend/user_microservice/package.json
@@ -16,6 +16,7 @@
     "@middy/http-security-headers": "^2.1.1",
     "@middy/validator": "^2.1.1",
     "crypto": "^1.0.1",
-    "http-errors": "^1.8.0"
+    "http-errors": "^1.8.0",
+    "jwt-decode": "^3.1.2"
   }
 }

--- a/lambda_backend/user_microservice/serverless.yml
+++ b/lambda_backend/user_microservice/serverless.yml
@@ -25,6 +25,7 @@ provider:
             - cognito-idp:InitiateAuth
             - cognito-idp:AdminGetUser
             - cognito-idp:AdminUpdateUserAttributes
+            - cognito-idp:AdminDisableUser
           Resource: ${self:custom.cognitoArn}
 
 plugins:
@@ -114,6 +115,19 @@ functions:
       - http:
           path: user/delete
           method: delete
+          cors:
+            origin: ${self:custom._origin.${self:custom.stage}}
+          authorizer:
+            arn: ${self:custom.cognitoArn}
+            scopes:
+              - aws.cognito.signin.user.admin
+
+  disableUser:
+    handler: src/disableUser.handler
+    events:
+      - http:
+          path: user/disable
+          method: post
           cors:
             origin: ${self:custom._origin.${self:custom.stage}}
           authorizer:

--- a/lambda_backend/user_microservice/serverless.yml
+++ b/lambda_backend/user_microservice/serverless.yml
@@ -23,10 +23,8 @@ provider:
             - cognito-idp:SignUp
             - cognito-idp:ConfirmSignUp
             - cognito-idp:InitiateAuth
-          Resource: ${self:custom.cognitoArn}
-        - Effect: Allow
-          Action:
             - cognito-idp:AdminGetUser
+            - cognito-idp:AdminUpdateUserAttributes
           Resource: ${self:custom.cognitoArn}
 
 plugins:
@@ -122,6 +120,9 @@ functions:
             arn: ${self:custom.cognitoArn}
             scopes:
               - aws.cognito.signin.user.admin
+
+  enableAdmin:
+    handler: src/enableAdmin.handler
 
 custom:
   stage: ${opt:stage, self:provider.stage}

--- a/lambda_backend/user_microservice/serverless.yml
+++ b/lambda_backend/user_microservice/serverless.yml
@@ -13,6 +13,7 @@ provider:
     ALLOWED_ORIGIN: ${self:custom._origin.${self:custom.stage}}
     COGNITO_CLIENT_ID: ${self:custom.cognitoClientId}
     COGNITO_USERPOOL_ID: ${self:custom.cognitoUserpoolId}
+    TELEGRAM_SNS_ARN: ${self:custom.telegramSNSArn}
   logRetentionInDays: 30
   lambdaHashingVersion: 20201221
   iam:
@@ -27,6 +28,11 @@ provider:
             - cognito-idp:AdminUpdateUserAttributes
             - cognito-idp:AdminDisableUser
           Resource: ${self:custom.cognitoArn}
+        - Effect: Allow
+          Action:
+            - sns:publish
+          Resource:
+            - '${self:custom.telegramSNSArn}'
 
 plugins:
   - serverless-plugin-typescript
@@ -135,6 +141,19 @@ functions:
             scopes:
               - aws.cognito.signin.user.admin
 
+  reportUser:
+    handler: src/reportUser.handler
+    events:
+      - http:
+          path: user/report
+          method: post
+          cors:
+            origin: ${self:custom._origin.${self:custom.stage}}
+          authorizer:
+            arn: ${self:custom.cognitoArn}
+            scopes:
+              - aws.cognito.signin.user.admin
+
   enableAdmin:
     handler: src/enableAdmin.handler
 
@@ -143,6 +162,7 @@ custom:
   cognitoArn: ${ssm:/${self:custom.stage}/cognito/arn}
   cognitoClientId: ${ssm:/${self:custom.stage}/cognito/clientId}
   cognitoUserpoolId: ${ssm:/${self:custom.stage}/cognito/poolId}
+  telegramSNSArn: ${ssm:/${self:custom.stage}/sns/telegram/arn}
   apiGatewayThrottling:
     maxRequestsPerSecond: ${self:custom._maxRequestsPerSecond.${self:custom.stage}}
     maxConcurrentRequests: ${self:custom._maxConcurrentRequests.${self:custom.stage}}

--- a/lambda_backend/user_microservice/src/common/identityProvider.ts
+++ b/lambda_backend/user_microservice/src/common/identityProvider.ts
@@ -5,6 +5,7 @@ import CognitoIdentityServiceProvider, {
   AttributeType,
   GetUserRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
+import { CognitoUserDetails, UserRole } from './types';
 import createError from 'http-errors';
 
 const cognitoIdentity = new CognitoIdentityServiceProvider();
@@ -65,10 +66,3 @@ const parseUserAttributes = (UserAttributes: AttributeType[]): CognitoUserDetail
     .Value as UserRole;
   return { userEmail, userRole };
 };
-
-interface CognitoUserDetails {
-  userEmail: string;
-  userRole: UserRole;
-}
-
-type UserRole = 'admin' | 'user';

--- a/lambda_backend/user_microservice/src/common/identityProvider.ts
+++ b/lambda_backend/user_microservice/src/common/identityProvider.ts
@@ -1,10 +1,24 @@
 import CognitoIdentityServiceProvider, {
   AdminGetUserRequest,
+  AdminUpdateUserAttributesRequest,
   AttributeType,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
 import createError from 'http-errors';
 
 const cognitoIdentity = new CognitoIdentityServiceProvider();
+
+export const enableAdminPermission = async (Username: string): Promise<void> => {
+  const adminUpdateUserAttributesParams: AdminUpdateUserAttributesRequest = {
+    Username,
+    UserPoolId: process.env['COGNITO_USERPOOL_ID'] as string,
+    UserAttributes: [{ Name: 'custom:role', Value: 'admin' }],
+  };
+  try {
+    await cognitoIdentity.adminUpdateUserAttributes(adminUpdateUserAttributesParams).promise();
+  } catch (error) {
+    throw createError(500, 'Error updating Cognito user details');
+  }
+};
 
 export const adminGetCognitoUserDetails = async (Username: string): Promise<CognitoUserDetails> => {
   const adminGetUserParams: AdminGetUserRequest = {

--- a/lambda_backend/user_microservice/src/common/identityProvider.ts
+++ b/lambda_backend/user_microservice/src/common/identityProvider.ts
@@ -62,11 +62,13 @@ const parseUserAttributes = (UserAttributes: AttributeType[]): CognitoUserDetail
   const userEmail = UserAttributes.filter((attribute) => attribute.Name === 'email')[0]
     .Value as string;
   const userRole = UserAttributes.filter((attribute) => attribute.Name === 'custom:role')[0]
-    .Value as 'admin' | 'user';
+    .Value as UserRole;
   return { userEmail, userRole };
 };
 
 interface CognitoUserDetails {
   userEmail: string;
-  userRole: 'admin' | 'user';
+  userRole: UserRole;
 }
+
+type UserRole = 'admin' | 'user';

--- a/lambda_backend/user_microservice/src/common/index.ts
+++ b/lambda_backend/user_microservice/src/common/index.ts
@@ -1,4 +1,0 @@
-export * from './types';
-export * from './schema';
-export * from './middleware';
-export * from './identityProvider';

--- a/lambda_backend/user_microservice/src/common/schema.ts
+++ b/lambda_backend/user_microservice/src/common/schema.ts
@@ -61,6 +61,8 @@ export const resendCodeSchema = identiferSchema;
 
 export const forgotPasswordSchema = identiferSchema;
 
+export const disableUserSchema = identiferSchema;
+
 export const confirmForgotPasswordSchema = {
   type: 'object',
   properties: {

--- a/lambda_backend/user_microservice/src/common/schema.ts
+++ b/lambda_backend/user_microservice/src/common/schema.ts
@@ -63,6 +63,20 @@ export const forgotPasswordSchema = identiferSchema;
 
 export const disableUserSchema = identiferSchema;
 
+export const reportUserSchema = {
+  type: 'object',
+  properties: {
+    body: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', pattern: AlphanumericSpace, maxLength: 20 },
+        reason: { type: 'string', pattern: AlphanumericSpace, maxLength: 20 },
+      },
+      required: ['name', 'reason'],
+    },
+  },
+};
+
 export const confirmForgotPasswordSchema = {
   type: 'object',
   properties: {

--- a/lambda_backend/user_microservice/src/common/types.ts
+++ b/lambda_backend/user_microservice/src/common/types.ts
@@ -76,3 +76,10 @@ export interface JwtPayload {
   client_id: string;
   username: string;
 }
+
+export interface CognitoUserDetails {
+  userEmail: string;
+  userRole: UserRole;
+}
+
+export type UserRole = 'admin' | 'user';

--- a/lambda_backend/user_microservice/src/common/types.ts
+++ b/lambda_backend/user_microservice/src/common/types.ts
@@ -53,3 +53,5 @@ interface AuthHeader {
 export type LogoutEvent = AuthHeader;
 
 export type DeleteEvent = AuthHeader;
+
+export interface DisableUserEvent extends AuthHeader, UserIdentifer {}

--- a/lambda_backend/user_microservice/src/common/types.ts
+++ b/lambda_backend/user_microservice/src/common/types.ts
@@ -55,3 +55,24 @@ export type LogoutEvent = AuthHeader;
 export type DeleteEvent = AuthHeader;
 
 export interface DisableUserEvent extends AuthHeader, UserIdentifer {}
+
+export interface ReportUserEvent extends AuthHeader {
+  body: {
+    name: string;
+    reason: string;
+  };
+}
+
+export interface JwtPayload {
+  sub: string;
+  event_id: string;
+  token_use: string;
+  scope: 'aws.cognito.signin.user.admin';
+  auth_time: number;
+  iss: string;
+  exp: number;
+  iat: number;
+  jti: string;
+  client_id: string;
+  username: string;
+}

--- a/lambda_backend/user_microservice/src/confirmForgotPassword.ts
+++ b/lambda_backend/user_microservice/src/confirmForgotPassword.ts
@@ -2,11 +2,10 @@ import { Handler } from 'aws-lambda';
 import CognitoIdentity, {
   ConfirmForgotPasswordRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import {
-  ConfirmForgotPasswordEvent,
-  confirmForgotPasswordSchema,
-  getMiddlewareAddedHandler,
-} from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { ConfirmForgotPasswordEvent } from './common/types';
+import { confirmForgotPasswordSchema } from './common/schema';
 
 const cognitoIdentity = new CognitoIdentity();
 

--- a/lambda_backend/user_microservice/src/confirmSignup.ts
+++ b/lambda_backend/user_microservice/src/confirmSignup.ts
@@ -2,7 +2,10 @@ import { Handler } from 'aws-lambda';
 import CognitoIdentity, {
   ConfirmSignUpRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { ConfirmSignupEvent, confirmSignupSchema, getMiddlewareAddedHandler } from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { ConfirmSignupEvent } from './common/types';
+import { confirmSignupSchema } from './common/schema';
 
 const cognitoIdentity = new CognitoIdentity();
 

--- a/lambda_backend/user_microservice/src/deleteUser.ts
+++ b/lambda_backend/user_microservice/src/deleteUser.ts
@@ -1,6 +1,8 @@
 import { Handler } from 'aws-lambda';
 import CognitoIdentity, { DeleteUserRequest } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { DeleteEvent, getMiddlewareAddedHandler } from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { DeleteEvent } from './common/types';
 
 const cognitoIdentity = new CognitoIdentity();
 

--- a/lambda_backend/user_microservice/src/disableUser.ts
+++ b/lambda_backend/user_microservice/src/disableUser.ts
@@ -1,0 +1,29 @@
+import { Handler } from 'aws-lambda';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { adminDisableUser, getCognitoUserDetails } from './common/identityProvider';
+import { disableUserSchema } from './common/schema';
+import { DisableUserEvent } from './common/types';
+
+const disableUser: Handler = async (event: DisableUserEvent) => {
+  const {
+    headers: { Authorization },
+    body: { name },
+  } = event;
+
+  const { userRole } = await getCognitoUserDetails(Authorization.split(' ')[1]);
+  if (userRole === 'admin') {
+    await adminDisableUser(name);
+  } else {
+    return {
+      statusCode: 403,
+      body: JSON.stringify({ Message: 'Unauthorized' }),
+    };
+  }
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ Message: 'Disable user success' }),
+  };
+};
+
+export const handler = getMiddlewareAddedHandler(disableUser, disableUserSchema);

--- a/lambda_backend/user_microservice/src/enableAdmin.ts
+++ b/lambda_backend/user_microservice/src/enableAdmin.ts
@@ -1,0 +1,14 @@
+import { Handler } from 'aws-lambda';
+
+import { enableAdminPermission } from './common/identityProvider';
+
+/**
+ * sls invoke --function enableAdmin --stage {stage} --region ap-southeast-1 --data {username}
+ */
+
+const enableAdmin: Handler = async (username: string) => {
+  await enableAdminPermission(username);
+  return 'Enable admin success';
+};
+
+export const handler = enableAdmin;

--- a/lambda_backend/user_microservice/src/forgotPassword.ts
+++ b/lambda_backend/user_microservice/src/forgotPassword.ts
@@ -2,7 +2,10 @@ import { Handler } from 'aws-lambda';
 import CognitoIdentity, {
   ForgotPasswordRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { ForgotPasswordEvent, forgotPasswordSchema, getMiddlewareAddedHandler } from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { ForgotPasswordEvent } from './common/types';
+import { forgotPasswordSchema } from './common/schema';
 
 const cognitoIdentity = new CognitoIdentity();
 

--- a/lambda_backend/user_microservice/src/login.ts
+++ b/lambda_backend/user_microservice/src/login.ts
@@ -2,12 +2,11 @@ import { Handler } from 'aws-lambda';
 import CognitoIdentity, {
   InitiateAuthRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import {
-  LoginEvent,
-  loginSchema,
-  getMiddlewareAddedHandler,
-  adminGetCognitoUserDetails,
-} from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { LoginEvent } from './common/types';
+import { loginSchema } from './common/schema';
+import { adminGetCognitoUserDetails } from './common/identityProvider';
 
 const cognitoIdentity = new CognitoIdentity();
 

--- a/lambda_backend/user_microservice/src/logout.ts
+++ b/lambda_backend/user_microservice/src/logout.ts
@@ -2,7 +2,9 @@ import { Handler } from 'aws-lambda';
 import CognitoIdentity, {
   GlobalSignOutRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { LogoutEvent, getMiddlewareAddedHandler } from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { LogoutEvent } from './common/types';
 
 const cognitoIdentity = new CognitoIdentity();
 

--- a/lambda_backend/user_microservice/src/refreshToken.ts
+++ b/lambda_backend/user_microservice/src/refreshToken.ts
@@ -2,7 +2,10 @@ import { Handler } from 'aws-lambda';
 import CognitoIdentity, {
   InitiateAuthRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { RefreshTokenEvent, refreshTokenSchema, getMiddlewareAddedHandler } from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { RefreshTokenEvent } from './common/types';
+import { refreshTokenSchema } from './common/schema';
 
 const cognitoIdentity = new CognitoIdentity();
 

--- a/lambda_backend/user_microservice/src/reportUser.ts
+++ b/lambda_backend/user_microservice/src/reportUser.ts
@@ -1,0 +1,49 @@
+import { Handler } from 'aws-lambda';
+import SNS, { PublishInput } from 'aws-sdk/clients/sns';
+import createError from 'http-errors';
+import jwt_decode from 'jwt-decode';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { reportUserSchema } from './common/schema';
+import { ReportUserEvent, JwtPayload } from './common/types';
+
+const SNSInstance = new SNS();
+
+const reportUser: Handler = async (event: ReportUserEvent) => {
+  if (!process.env['TELEGRAM_SNS_ARN']) {
+    throw createError(500, 'Telegram SNS ARN is not set');
+  }
+
+  const {
+    headers: { Authorization },
+    body: { name, reason },
+  } = event;
+
+  const { username: requestUsername } = (await jwt_decode(
+    Authorization.split(' ')[1],
+  )) as JwtPayload;
+
+  if (requestUsername === name) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ Message: 'Self report' }),
+    };
+  }
+
+  const publishInput: PublishInput = {
+    Message: `Report User\nBy: ${requestUsername}\nOn: ${name}\nFor: ${reason}`,
+    TopicArn: process.env['TELEGRAM_SNS_ARN'],
+  };
+  try {
+    await SNSInstance.publish(publishInput).promise();
+  } catch (error) {
+    throw createError(500, 'Error publishing SNS', error);
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ Message: 'Report user success' }),
+  };
+};
+
+export const handler = getMiddlewareAddedHandler(reportUser, reportUserSchema);

--- a/lambda_backend/user_microservice/src/resendCode.ts
+++ b/lambda_backend/user_microservice/src/resendCode.ts
@@ -2,7 +2,10 @@ import { Handler } from 'aws-lambda';
 import CognitoIdentity, {
   ResendConfirmationCodeRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { ResendCodeEvent, resendCodeSchema, getMiddlewareAddedHandler } from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { ResendCodeEvent } from './common/types';
+import { resendCodeSchema } from './common/schema';
 
 const cognitoIdentity = new CognitoIdentity();
 

--- a/lambda_backend/user_microservice/src/signup.ts
+++ b/lambda_backend/user_microservice/src/signup.ts
@@ -14,7 +14,10 @@ const signup: Handler = async (event: SignupEvent) => {
   const signUpRequest: SignUpRequest = {
     Username: name,
     Password: password,
-    UserAttributes: [{ Name: 'email', Value: email }],
+    UserAttributes: [
+      { Name: 'email', Value: email },
+      { Name: 'custom:role', Value: 'user' },
+    ],
     ClientId: process.env['COGNITO_CLIENT_ID'] || '',
   };
   try {

--- a/lambda_backend/user_microservice/src/signup.ts
+++ b/lambda_backend/user_microservice/src/signup.ts
@@ -1,6 +1,9 @@
 import { Handler } from 'aws-lambda';
 import CognitoIdentity, { SignUpRequest } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { SignupEvent, signupSchema, getMiddlewareAddedHandler } from './common';
+
+import { getMiddlewareAddedHandler } from './common/middleware';
+import { SignupEvent } from './common/types';
+import { signupSchema } from './common/schema';
 
 const cognitoIdentity = new CognitoIdentity();
 


### PR DESCRIPTION
Refer to the Issue #90 

Updated Postman and Swagger

#### Notes on admin privilege
Admins can delete any comments `DELETE /route/details/comment`
Admins can delete any routes `DELETE /route`
Admins can disable users `POST /user/disable`

To see whether someone is admin in the frontend, decode the idToken. Attribute `custom:role` will be `admin` or `user` for now
```
{
  "sub": "xxx",
  "email_verified": true,
  "iss": "xxx",
  "cognito:username": "yarkhinephyo",
  "origin_jti": "xxx",
  "aud": "xxx",
  "event_id": "xxx",
  "token_use": "id",
  "auth_time": 1624345868,
  "exp": 1624432268,
  "custom:role": "admin",  // New attribute
  "iat": 1624345869,
  "jti": "xxx",
  "email": "yarkhinephyo@gmail.com"
}
```

