### PR TITLE
Feature/Make canva mode buttons sticky

### DIFF
--- a/ionic_user_interface/src/components/wall-image-viewer/Canvas.vue
+++ b/ionic_user_interface/src/components/wall-image-viewer/Canvas.vue
@@ -355,7 +355,7 @@ ion-button::part(native) {
 }
 
 .button-rows {
-  background-color: white;
+  background-color: var(--ion-background-color);
   position: sticky;
   position: -webkit-sticky; /* Safari */
   top: 0px;

--- a/ionic_user_interface/src/components/wall-image-viewer/Canvas.vue
+++ b/ionic_user_interface/src/components/wall-image-viewer/Canvas.vue
@@ -2,59 +2,71 @@
   <div>
     <br />
     <br />
-    <ion-segment
-      class="mode-switcher"
-      @ionChange="selectModeChanged($event)"
-      color="tertiary"
-      mode="ios"
-      :value="selectedMode"
-    >
-      <ion-segment-button :value="SelectMode.HANDHOLD">
-        <ion-label>HandHold</ion-label>
-      </ion-segment-button>
-      <ion-segment-button :value="SelectMode.FOOTHOLD">
-        <ion-label>FootHold</ion-label>
-      </ion-segment-button>
-      <ion-segment-button :value="SelectMode.DRAWBOX">
-        <ion-label>DrawBox</ion-label>
-      </ion-segment-button>
-      <ion-segment-button :value="SelectMode.MARKDONE">
-        <ion-label>MarkDone</ion-label>
-      </ion-segment-button>
-    </ion-segment>
-    <div v-if="+selectedMode === SelectMode.MARKDONE">
-      <ion-button @click="handleExportClick" class="solid-button" fill="outline" color="secondary">
-        Export
-      </ion-button>
-      <ion-button @click="handlePostClick" class="solid-button" fill="solid" color="primary">
-        Post
-      </ion-button>
-    </div>
-    <div v-if="+selectedMode === SelectMode.HANDHOLD || +selectedMode === SelectMode.FOOTHOLD">
-      <ion-button
-        class="outline-button"
-        @click="handleHideNumbersClick"
-        :fill="hideNumbersFill"
+    <div class="button-rows">
+      <ion-segment
+        class="mode-switcher"
+        @ionChange="selectModeChanged($event)"
         color="tertiary"
+        mode="ios"
+        :value="selectedMode"
       >
-        {{ hideNumbersText }}
-      </ion-button>
-      <ion-button class="outline-button" @click="handleTapeClick" :fill="tapeFill" color="primary">
-        {{ tapeText }}
-      </ion-button>
-      <ion-button class="solid-button" fill="solid" color="danger" @click="handleReset">
-        Reset
+        <ion-segment-button :value="SelectMode.HANDHOLD">
+          <ion-label>HandHold</ion-label>
+        </ion-segment-button>
+        <ion-segment-button :value="SelectMode.FOOTHOLD">
+          <ion-label>FootHold</ion-label>
+        </ion-segment-button>
+        <ion-segment-button :value="SelectMode.DRAWBOX">
+          <ion-label>DrawBox</ion-label>
+        </ion-segment-button>
+        <ion-segment-button :value="SelectMode.MARKDONE">
+          <ion-label>MarkDone</ion-label>
+        </ion-segment-button>
+      </ion-segment>
+      <div v-if="+selectedMode === SelectMode.MARKDONE">
+        <ion-button
+          @click="handleExportClick"
+          class="solid-button"
+          fill="outline"
+          color="secondary"
+        >
+          Export
+        </ion-button>
+        <ion-button @click="handlePostClick" class="solid-button" fill="solid" color="primary">
+          Post
+        </ion-button>
+      </div>
+      <div v-if="+selectedMode === SelectMode.HANDHOLD || +selectedMode === SelectMode.FOOTHOLD">
+        <ion-button
+          class="outline-button"
+          @click="handleHideNumbersClick"
+          :fill="hideNumbersFill"
+          color="tertiary"
+        >
+          {{ hideNumbersText }}
+        </ion-button>
+        <ion-button
+          class="outline-button"
+          @click="handleTapeClick"
+          :fill="tapeFill"
+          color="primary"
+        >
+          {{ tapeText }}
+        </ion-button>
+        <ion-button class="solid-button" fill="solid" color="danger" @click="handleReset">
+          Reset
+        </ion-button>
+      </div>
+      <ion-button
+        v-if="+selectedMode === SelectMode.DRAWBOX"
+        @click="handleUndoDraw"
+        class="solid-button"
+        fill="solid"
+        color="danger"
+      >
+        Undo Draw
       </ion-button>
     </div>
-    <ion-button
-      v-if="+selectedMode === SelectMode.DRAWBOX"
-      @click="handleUndoDraw"
-      class="solid-button"
-      fill="solid"
-      color="danger"
-    >
-      Undo Draw
-    </ion-button>
     <div id="konva-container" class="konva-container"></div>
   </div>
 </template>
@@ -340,5 +352,14 @@ ion-button::part(native) {
 .konva-container {
   width: max-content;
   margin: 0 auto;
+}
+
+.button-rows {
+  background-color: white;
+  position: sticky;
+  position: -webkit-sticky; /* Safari */
+  top: 0px;
+  padding-top: 10px;
+  z-index: 10;
 }
 </style>

--- a/ionic_user_interface/src/theme/variables.css
+++ b/ionic_user_interface/src/theme/variables.css
@@ -25,6 +25,9 @@ http://ionicframework.com/docs/theming/ */
 :root {
   --ion-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', Oxygen, Ubuntu,
     Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  --ion-background-color: #ffffff;
+  --ion-background-color-rgb: 255, 255, 255;
+
   /** primary **/
   --ion-color-primary: #3880ff;
   --ion-color-primary-rgb: 56, 128, 255;

--- a/ionic_user_interface/src/views/Home.vue
+++ b/ionic_user_interface/src/views/Home.vue
@@ -2,9 +2,12 @@
   <ion-page>
     <ion-content :fullscreen="true">
       <div id="container">
-        <strong>Route Maker</strong>
-        <p>Quickly make custom climbing routes</p>
-        <br />
+        <div v-if="!photoData">
+          <strong>Route Maker</strong>
+          <p>Quickly make custom climbing routes</p>
+          <br />
+          <br />
+        </div>
         <br />
         <ion-button @click="takePhoto()" color="tertiary">
           <ion-icon class="camera-icon" :icon="camera"></ion-icon>

--- a/ionic_user_interface/src/views/Home.vue
+++ b/ionic_user_interface/src/views/Home.vue
@@ -2,12 +2,9 @@
   <ion-page>
     <ion-content :fullscreen="true">
       <div id="container">
-        <div v-if="!photoData">
-          <strong>Route Maker</strong>
-          <p>Quickly make custom climbing routes</p>
-          <br />
-          <br />
-        </div>
+        <strong>Route Maker</strong>
+        <p>Quickly make custom climbing routes</p>
+        <br />
         <br />
         <ion-button @click="takePhoto()" color="tertiary">
           <ion-icon class="camera-icon" :icon="camera"></ion-icon>


### PR DESCRIPTION
#### Summary
Make the mode buttons sticky when scrolling down.
![image](https://user-images.githubusercontent.com/19868916/123811250-a6c6dd00-d925-11eb-953a-01ada67a1214.png)

#### Testing
Temporarily, I will host this PR at https://yarkhinephyo.github.io/RouteMaker/home for easy testing with mobile browser.

##### Note
Sometimes, dragging canvas can fail (#74). Not resolved in this PR.