### PR TITLE
Fix/stuck canvas mobile

### DIFF
--- a/ionic_user_interface/src/components/wall-image-viewer/Canvas.vue
+++ b/ionic_user_interface/src/components/wall-image-viewer/Canvas.vue
@@ -73,8 +73,8 @@
 
 <script lang="ts">
 import Konva from 'konva';
-import { IonButton, IonLabel, IonSegment, IonSegmentButton } from '@ionic/vue';
-import { defineComponent, inject, onMounted, ref, watch } from 'vue';
+import { IonButton, IonLabel, IonSegment, IonSegmentButton, IonContent } from '@ionic/vue';
+import { defineComponent, inject, onMounted, ref, watch, PropType } from 'vue';
 import { useRouter } from 'vue-router';
 
 import getBoundingBoxes from '@/components/wall-image-viewer/getBoundingBoxes';
@@ -109,6 +109,10 @@ export default defineComponent({
     },
     width: {
       type: Number,
+      required: true,
+    },
+    ionContent: {
+      type: Object as PropType<typeof IonContent>,
       required: true,
     },
   },
@@ -172,7 +176,7 @@ export default defineComponent({
 
         // Listeners must be added after image is loaded
         addKonvaListenerPinchZoom(stage);
-        addKonvaListenerTouchMove(stage);
+        addKonvaListenerTouchMove(stage, props.ionContent);
       };
       image.src = props.imgSrc;
     };
@@ -205,7 +209,7 @@ export default defineComponent({
       } else if (+oldSelectedMode === SelectMode.DRAWBOX) {
         const newBoundingBoxes = DrawLayer.getKonvaDrawLayerBoundingBoxes(stage);
         DrawLayer.removeKonvaDrawLayer(stage);
-        addKonvaListenerTouchMove(stage);
+        addKonvaListenerTouchMove(stage, props.ionContent);
         addBoxLayerBoundingBoxes(newBoundingBoxes);
         imageLayer.batchDraw();
       }

--- a/ionic_user_interface/src/components/wall-image-viewer/stageListeners.ts
+++ b/ionic_user_interface/src/components/wall-image-viewer/stageListeners.ts
@@ -1,3 +1,4 @@
+import { IonContent } from '@ionic/vue';
 import Konva from 'konva';
 import { throttle } from 'lodash';
 
@@ -19,6 +20,8 @@ const addKonvaListenerPinchZoom = (stageNode: Konva.Stage): void => {
     'touchmove',
     throttle((e) => {
       e.evt.preventDefault();
+      if (e.evt.touches.length !== 2) return;
+
       const touch1 = e.evt.touches[0];
       const touch2 = e.evt.touches[1];
 
@@ -122,7 +125,7 @@ const addKonvaListenerPinchZoom = (stageNode: Konva.Stage): void => {
  * Add listener to the node which awaits for single touch events to move the node around
  * @param {node} stageNode
  */
-const addKonvaListenerTouchMove = (stageNode: Konva.Stage): void => {
+const addKonvaListenerTouchMove = (stageNode: Konva.Stage, ionContent: typeof IonContent): void => {
   let lastCenter: Point | null = null;
   const { width: imageWidth, height: imageHeight } = stageNode.size();
 
@@ -157,12 +160,15 @@ const addKonvaListenerTouchMove = (stageNode: Konva.Stage): void => {
         y: newPos.y + imageHeight * stageNode.scaleY(),
       };
 
-      // ensure the user cannot drag out of the bound
+      // ensure the user cannot drag out of the x & y bound
       if (newPos.x > 0 || bottomRightPos.x < imageWidth) {
         newPos.x = stageNode.x();
       }
+      // if the user tries to drag out of y-bound, scroll the window instead
+      // https://ionicframework.com/docs/api/content
       if (newPos.y > 0 || bottomRightPos.y < imageHeight) {
         newPos.y = stageNode.y();
+        ionContent.$el.scrollByPoint(0, dy, 0);
       }
 
       stageNode.position(newPos);

--- a/ionic_user_interface/src/components/wall-image-viewer/stageListeners.ts
+++ b/ionic_user_interface/src/components/wall-image-viewer/stageListeners.ts
@@ -168,7 +168,7 @@ const addKonvaListenerTouchMove = (stageNode: Konva.Stage, ionContent: typeof Io
       // https://ionicframework.com/docs/api/content
       if (newPos.y > 0 || bottomRightPos.y < imageHeight) {
         newPos.y = stageNode.y();
-        ionContent.$el.scrollByPoint(0, dy, 0);
+        ionContent.$el.scrollByPoint(0, -1 * dy, 0);
       }
 
       stageNode.position(newPos);

--- a/ionic_user_interface/src/components/wall-image-viewer/stageListeners.ts
+++ b/ionic_user_interface/src/components/wall-image-viewer/stageListeners.ts
@@ -166,6 +166,7 @@ const addKonvaListenerTouchMove = (stageNode: Konva.Stage, ionContent: typeof Io
       }
       // if the user tries to drag out of y-bound, scroll the window instead
       // https://ionicframework.com/docs/api/content
+      // BUG: https://github.com/ionic-team/ionic-framework/issues/22304
       if (newPos.y > 0 || bottomRightPos.y < imageHeight) {
         newPos.y = stageNode.y();
         ionContent.$el.scrollByPoint(0, -1 * dy, 0);

--- a/ionic_user_interface/src/views/Home.vue
+++ b/ionic_user_interface/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <ion-page>
-    <ion-content :fullscreen="true">
+    <ion-content :fullscreen="true" ref="ionContent">
       <div id="container">
         <strong>Route Maker</strong>
         <p>Quickly make custom climbing routes</p>
@@ -10,7 +10,12 @@
           <ion-icon class="camera-icon" :icon="camera"></ion-icon>
           Upload wall image
         </ion-button>
-        <Canvas v-if="photoUploaded" :imgSrc="photoData" :width="canvasWidth" />
+        <Canvas
+          v-if="photoUploaded"
+          :imgSrc="photoData"
+          :width="canvasWidth"
+          :ionContent="ionContent"
+        />
       </div>
     </ion-content>
   </ion-page>
@@ -40,6 +45,8 @@ export default defineComponent({
     const { photo, takePhoto } = usePhotoGallery();
     const { canvasWidth, updateCanvasWidth } = useCanvasWidth();
 
+    const ionContent = ref<typeof IonContent | null>(null);
+
     watch(photo, (oldPhoto, newPhoto) => {
       if (newPhoto !== oldPhoto && oldPhoto !== null) {
         photoUploaded.value = true;
@@ -49,6 +56,7 @@ export default defineComponent({
         updateCanvasWidth();
       }
     });
+
     window.addEventListener('resize', updateCanvasWidth);
 
     onMounted(() => {
@@ -66,6 +74,7 @@ export default defineComponent({
       photo,
       takePhoto,
       camera,
+      ionContent,
     };
   },
 });


### PR DESCRIPTION
## Summary
Fix the glitch in scrolling with canvas on mobile by scrolling the window up and down when user drag the picture out of bounds.

Optimize a two finger listener by ignoring events with non-two-fingers.

### Testing
https://hammerjs.github.io/touch-emulator/
Scroll down to "Bookmarklet" to simulate one and two finger `touchmoves`.
Have tested on mobile browser by deploying in a temporary page.
