### PR TITLE
Fix/Bugs creating a second route

### DIFF
--- a/ionic_user_interface/src/components/wall-image-viewer/Canvas.vue
+++ b/ionic_user_interface/src/components/wall-image-viewer/Canvas.vue
@@ -12,7 +12,7 @@
           class="instruction-arrow shift-down"
           v-if="routeMakingStep > 0"
           slot="start"
-          @click="changeRouteMakingStep(false)"
+          @click="changeRouteMakingStep(routeMakingStep - 1)"
         >
           <ion-icon :icon="caretBackOutline"></ion-icon>
         </div>
@@ -27,7 +27,7 @@
           class="instruction-arrow"
           v-if="routeMakingStep < 4"
           slot="end"
-          @click="changeRouteMakingStep(true)"
+          @click="changeRouteMakingStep(routeMakingStep + 1)"
         >
           <ion-icon :icon="caretForwardOutline"></ion-icon>
         </div>
@@ -322,7 +322,7 @@ export default defineComponent({
     watch(
       () => props.imgSrc,
       async () => {
-        offKonvaStageListeners(stage);
+        changeRouteMakingStep(0);
         await loadImageOnStage();
       },
     );
@@ -330,14 +330,10 @@ export default defineComponent({
     /**
      * Depending on the step of the route making process, the canvas mode is switched accordingly
      */
-    const changeRouteMakingStep = (doIncrement: boolean) => {
-      if (doIncrement) {
-        if (routeMakingStep.value + 1 > 4) return;
-        routeMakingStep.value = routeMakingStep.value + 1;
-      } else {
-        if (routeMakingStep.value - 1 < 0) return;
-        routeMakingStep.value = routeMakingStep.value - 1;
-      }
+    const changeRouteMakingStep = (step: number) => {
+      if (step > 4 || step < 0) return;
+      routeMakingStep.value = step;
+
       switch (routeMakingStep.value) {
         case 0:
           changeSelectMode(SelectMode.DRAWBOX);

--- a/ionic_user_interface/src/components/wall-image-viewer/box-layer/drawLayer.ts
+++ b/ionic_user_interface/src/components/wall-image-viewer/box-layer/drawLayer.ts
@@ -17,6 +17,11 @@ const DRAW_LAYER_NAME = 'drawLayer';
  * @param {node} stageNode
  */
 const addKonvaDrawLayer = (stageNode: Konva.Stage): void => {
+  // Remove the old draw layer if it exists
+  if (isDrawLayerAdded(stageNode)) {
+    removeKonvaDrawLayer(stageNode);
+  }
+
   const { width: imageWidth, height: imageHeight } = stageNode.size();
 
   const drawLayer = new Konva.Layer({ name: DRAW_LAYER_NAME, draggable: false });

--- a/ionic_user_interface/src/components/wall-image-viewer/box-layer/useBoxLayer.ts
+++ b/ionic_user_interface/src/components/wall-image-viewer/box-layer/useBoxLayer.ts
@@ -16,9 +16,13 @@ export function useBoxLayer(
   const handholdPositionArr = ref<Array<number>>([]);
 
   const clearBoxLayer = () => {
+    // Destroy konva elements in the box layer
     boxLayer.clear();
     boxLayer.destroyChildren();
     boxLayer.batchDraw();
+    // Reset the tracking of bounding boxes
+    boundingBoxes = [];
+    handholdPositionArr.value = [];
   };
 
   /**


### PR DESCRIPTION
## Fix Problems

When uploading a second route after drawing out one -
1. The `Undo` function for drawing boxes stops working
2. The numbering does not start from 1