### PR TITLE
Gym request bug fix

### DIFF
--- a/ionic_user_interface/src/components/gym-selector/AutoComplete.vue
+++ b/ionic_user_interface/src/components/gym-selector/AutoComplete.vue
@@ -84,8 +84,15 @@ export default defineComponent({
             .toLowerCase()
             .indexOf(userInput.value.toLowerCase()) === 0,
       );
+
+      //Check if user is selecting United States (edge case)
+      if(userInput.value === "United States"){
+        showList.value = false
+        const matchedUS = filteredSuggestions.value[0].country === "United States" ? filteredSuggestions.value[0] : null;
+        emit('matchedItem', matchedUS);
+      }
       // Don't show anymore if the user input is the same as suggestion
-      if (
+      else if (
         filteredSuggestions.value.length === 1 &&
         filteredSuggestions.value[0][props.optionsKey as string] === userInput.value
       ) {


### PR DESCRIPTION
Allow users to select _United States_ as a country when making a gym request.

**Issue:**
Previously when a user selected United States as a country when creating a Gym Request, the form would display the error "Invalid Country". Upon closer inspection, it turned out that selecting United States resulted in a null value for `country`.  This is due to two selections that start with "United States":

- United States
- United States Minor Outlying Islands

**Solution:**
Add a check for when a user selects United States specifically and emit `matchedItem`.